### PR TITLE
Docs: Selective Connection Routing Phase Document

### DIFF
--- a/docs/01-selective-connection-routing-phase.md
+++ b/docs/01-selective-connection-routing-phase.md
@@ -13,12 +13,34 @@ Each Ableton instance runs AbletonOSC on different ports/IPs.
 - Track number is stored in group.tag parameter
 - Child scripts inherit parent tag as track number
 
-## Recommended Solution: Configuration-Based Routing with Prefix Naming
+## AbletonOSC Capabilities & Limitations
+
+### What AbletonOSC CAN do:
+- Track addressing by INDEX only (e.g., `/live/track/0/volume`)
+- Get track names via `/live/song/get/track_names`
+- Listen for property changes on individual tracks
+- Query track properties (name, volume, mute, etc.)
+- Bulk data queries via `/live/song/get/track_data`
+
+### What AbletonOSC CANNOT do:
+- No track addressing by name
+- No automatic track reorder notifications
+- No track list change detection
+- Only index-based addressing supported
+
+### Track Reordering Challenge
+When users reorder tracks in Ableton:
+- Track indices change but TouchOSC isn't notified
+- Stored track numbers become incorrect
+- Faders control wrong tracks
+
+## Recommended Solution: Configuration-Based Routing with Refresh Mechanisms
 
 ### Overview
-1. **Configuration Objects**: Create text objects that define which connection to use for each instance
+1. **Configuration Objects**: Text objects define which connection to use for each instance
 2. **Group Naming**: Add instance prefix to group names (e.g., `band_Hand 1 #`)
 3. **Script Routing**: Scripts read configuration and route messages accordingly
+4. **Refresh Mechanisms**: Multiple strategies to handle track reordering
 
 ### Architecture Diagram
 ```
@@ -28,11 +50,20 @@ Root/Project Page
 │   ├── connection_master (text: "2")
 │   └── connection_drums (text: "3")  // Future
 │
+├── Global Controls
+│   ├── refresh_all_button
+│   └── auto_refresh_toggle
+│
 └── Track Groups
-    ├── band_Hand 1 # (routes to connection 1)
-    ├── band_Hand 2 # (routes to connection 1)
-    ├── master_Vox 1 # (routes to connection 2)
-    └── master_Vox 2 # (routes to connection 2)
+    ├── band_Hand 1 # 
+    │   ├── refresh_button
+    │   ├── status_indicator
+    │   └── [controls...]
+    ├── master_Vox 1 #
+    │   ├── refresh_button
+    │   ├── status_indicator
+    │   └── [controls...]
+    └── ...
 ```
 
 ## Implementation Phases
@@ -84,317 +115,372 @@ Root/Project Page
            return "band", name  -- default
        end
    end
+   
+   -- Global refresh function
+   function refreshAllGroups()
+       local groups = root:findAllByProperty("tag", "trackGroup", true)
+       for _, group in ipairs(groups) do
+           group:notify("refresh")
+       end
+   end
    ```
 
-### Phase 1: Single Group Test (Non-Breaking)
-**Goal**: Test with one group without affecting others
+### Phase 1: Single Group Test with Refresh
+**Goal**: Test with one group including refresh mechanisms
 
 1. **Duplicate One Group**:
    - Copy existing group (e.g., 'Hand 1 #')
    - Rename to 'band_Hand 1 #'
+   - Add custom property: tag = "trackGroup"
    - Keep original for comparison
 
-2. **Update Initialization Script** (only in test group):
+2. **Add Refresh Controls**:
+   - Add refresh button to group
+   - Add status indicator (label or LED)
+   
+3. **Update Initialization Script**:
    ```lua
    function init()
        -- Parse group name
        local instance, trackName = parseGroupName(self.name)
-       self.tempInstance = instance
        
-       -- Get connection from config
-       local connectionIndex = getConnectionIndex(instance)
-       local connections = buildConnectionTable(connectionIndex)
+       -- Store data in script variables (not just tag)
+       self.instance = instance
+       self.trackName = trackName
+       self.connectionIndex = getConnectionIndex(instance)
+       self.lastVerified = getMillis()
+       
+       -- Initial track discovery
+       refreshTrackMapping()
+   end
+   
+   function refreshTrackMapping()
+       print("Refreshing track mapping for:", self.name)
+       self.needsRefresh = true
+       
+       -- Visual feedback
+       if self.children.status_indicator then
+           self.children.status_indicator.color = {1, 1, 0}  -- Yellow = refreshing
+       end
        
        -- Request track names from specific connection
+       local connections = buildConnectionTable(self.connectionIndex)
        sendOSC('/live/song/get/track_names', nil, connections)
    end
    
    function onReceiveOSC(message, connections)
        -- Filter by connection
-       local instance = self.tempInstance or parseGroupName(self.name)
-       local expectedConnection = getConnectionIndex(instance)
+       if not connections[self.connectionIndex] then return end
        
-       if not connections[expectedConnection] then
-           return  -- Wrong connection
+       local path = message[1]
+       if path == '/live/song/get/track_names' and self.needsRefresh then
+           local arguments = message[2]
+           local trackFound = false
+           
+           for i = 1, #arguments do
+               if arguments[i].value == self.trackName then
+                   -- Found our track
+                   self.trackNumber = i - 1
+                   self.lastVerified = getMillis()
+                   self.needsRefresh = false
+                   trackFound = true
+                   
+                   -- Update status
+                   if self.children.status_indicator then
+                       self.children.status_indicator.color = {0, 1, 0}  -- Green = OK
+                   end
+                   
+                   -- Store in tag for backwards compatibility
+                   self.tag = self.instance .. ":" .. self.trackNumber
+                   
+                   -- Start listeners
+                   local targetConnections = buildConnectionTable(self.connectionIndex)
+                   sendOSC('/live/track/start_listen/volume', {self.trackNumber}, targetConnections)
+                   sendOSC('/live/track/start_listen/output_meter_level', {self.trackNumber}, targetConnections)
+                   sendOSC('/live/track/start_listen/mute', {self.trackNumber}, targetConnections)
+                   sendOSC('/live/track/start_listen/panning', {self.trackNumber}, targetConnections)
+                   
+                   -- Update label
+                   self.children["fdr_label"].values.text = self.trackName:match("(%w+)(.*)")
+                   break
+               end
+           end
+           
+           if not trackFound then
+               -- Track not found
+               self.children["fdr_label"].values.text = "???"
+               if self.children.status_indicator then
+                   self.children.status_indicator.color = {1, 0, 0}  -- Red = Error
+               end
+               print("Track not found:", self.trackName)
+           end
        end
-       
-       -- [Rest of existing logic with connection-aware sending]
+   end
+   
+   function onNotify(param)
+       if param == "refresh" then
+           refreshTrackMapping()
+       end
+   end
+   
+   function update()
+       -- Visual feedback for stale data
+       local age = getMillis() - self.lastVerified
+       if age > 60000 and self.children.status_indicator then  -- 1 minute
+           self.children.status_indicator.color = {1, 0.5, 0}  -- Orange = Stale
+       end
    end
    ```
 
-3. **Test Checklist**:
-   - [ ] Group finds correct track number
-   - [ ] Initialization only talks to band Ableton
-   - [ ] No interference with original groups
-   - [ ] Configuration change (text "1" → "2") works
+4. **Add Refresh Button Script**:
+   ```lua
+   -- In refresh button
+   function onValueChanged(key)
+       if key == "x" and self.values.x == 1 then
+           self.parent:notify("refresh")
+           self.values.x = 0  -- Reset button
+       end
+   end
+   ```
 
-### Phase 2: Single Control Migration
-**Goal**: Test one control with script-based routing
+### Phase 2: Single Control Migration with Robust Sending
+**Goal**: Test one control with connection-aware script
 
-1. **Choose Simple Control** (e.g., volume fader in test group)
-
-2. **Migration Steps**:
-   - Note current OSC message address
-   - Disable GUI "Send" (keep "Receive" for now)
-   - Add script sending:
+1. **Update Fader Script**:
    ```lua
    function onValueChanged(key)
        if key == "x" and self.values.touch then
-           local parentTag = self.parent.tag
-           local instance, trackNumber = parentTag:match("([^:]+):(.+)")
+           local parent = self.parent
            
-           local connectionIndex = getConnectionIndex(instance)
-           local connections = buildConnectionTable(connectionIndex)
+           -- Validate parent has required data
+           if not parent.trackNumber or not parent.connectionIndex then
+               print("Error: Parent not initialized")
+               return
+           end
            
-           sendOSC("/live/track/" .. trackNumber .. "/volume", 
+           -- Build connection table
+           local connections = buildConnectionTable(parent.connectionIndex)
+           
+           -- Send to specific Ableton instance
+           sendOSC("/live/track/" .. parent.trackNumber .. "/volume", 
                    {self.values.x}, connections)
        end
    end
    ```
 
-3. **Test**:
-   - [ ] Fader sends only to band Ableton
-   - [ ] Other faders still work normally
-   - [ ] Changing connection_band text changes routing
-
-### Phase 3: Bidirectional Test
+### Phase 3: Bidirectional with Connection Filtering
 **Goal**: Add receiving with connection filtering
 
-1. **Add Receive Script** to same fader:
+```lua
+function onReceiveOSC(message, connections)
+    local parent = self.parent
+    
+    -- Validate parent
+    if not parent.trackNumber or not parent.connectionIndex then return end
+    
+    -- Filter by connection
+    if not connections[parent.connectionIndex] then return end
+    
+    -- Process message
+    local path = message[1]
+    local expectedPath = "/live/track/" .. parent.trackNumber .. "/volume"
+    
+    if path == expectedPath and message[2][1] then
+        self.values.x = message[2][1].value
+    end
+end
+```
+
+### Phase 4: Add Auto-Refresh Option
+**Goal**: Implement optional automatic refresh
+
+1. **Create Global Auto-Refresh Toggle**:
    ```lua
-   function onReceiveOSC(message, connections)
-       local parentTag = self.parent.tag
-       local instance, trackNumber = parentTag:match("([^:]+):(.+)")
-       local expectedConnection = getConnectionIndex(instance)
-       
-       if not connections[expectedConnection] then
-           return  -- Wrong connection
-       end
-       
-       -- Process message
-       local path = message[1]
-       local expectedPath = "/live/track/" .. trackNumber .. "/volume"
-       
-       if path == expectedPath and message[2][1] then
-           self.values.x = message[2][1].value
+   -- At document root
+   function init()
+       self.autoRefreshEnabled = false
+       self.autoRefreshInterval = 30  -- seconds
+       self.autoRefreshTimer = 0
+   end
+   
+   function update()
+       if self.autoRefreshEnabled then
+           self.autoRefreshTimer = self.autoRefreshTimer + getFrameDelta()
+           if self.autoRefreshTimer > self.autoRefreshInterval then
+               refreshAllGroups()
+               self.autoRefreshTimer = 0
+           end
        end
    end
    ```
 
-2. **Test**:
-   - [ ] Fader receives only from band Ableton
-   - [ ] Moving fader in Ableton updates TouchOSC
-   - [ ] No cross-talk from master Ableton
+### Phase 5: Full Group Migration
+**Goal**: Migrate all controls in test group with templates
 
-### Phase 4: Full Group Migration
-**Goal**: Migrate all controls in test group
+### Phase 6: Multi-Instance Test
+**Goal**: Test band and master groups together
 
-1. **Create Script Templates** for common controls:
-   - Fader script
-   - Button script
-   - Meter script
-   - Label script
-
-2. **Systematic Migration**:
-   - List all controls in group
-   - Apply appropriate template to each
-   - Test each control individually
-
-3. **Group Test**:
-   - [ ] All controls route correctly
-   - [ ] No performance issues
-   - [ ] Configuration changes work
-
-### Phase 5: Second Instance Test
-**Goal**: Verify multiple instances work together
-
-1. **Create Master Group**:
-   - Copy a different group
-   - Rename with 'master_' prefix
-   - Apply same migration steps
-
-2. **Cross-Instance Test**:
-   - [ ] Band groups only talk to band Ableton
-   - [ ] Master groups only talk to master Ableton
-   - [ ] Can run both simultaneously
-   - [ ] No cross-talk
-
-### Phase 6: Full Rollout
-**Goal**: Migrate all groups systematically
-
-1. **Migration Order**:
-   - Critical groups first
-   - Similar groups in batches
-   - Non-critical groups last
-
-2. **Rollback Plan**:
-   - Keep original groups disabled but not deleted
-   - Can revert by renaming back
-   - Document any issues found
+### Phase 7: Full Rollout with Monitoring
+**Goal**: Migrate all groups with refresh mechanisms
 
 ## Script Templates
 
-### Parent Group Initialization
+### Parent Group with Refresh Support
 ```lua
 function init()
+    -- Parse and store info
     local instance, trackName = parseGroupName(self.name)
-    self.tempInstance = instance
+    self.instance = instance
+    self.trackName = trackName
+    self.connectionIndex = getConnectionIndex(instance)
+    self.trackNumber = nil  -- Will be set by refresh
+    self.lastVerified = 0
     
-    local connectionIndex = getConnectionIndex(instance)
-    local connections = buildConnectionTable(connectionIndex)
+    -- Initial refresh
+    refreshTrackMapping()
+end
+
+function refreshTrackMapping()
+    print("Refreshing:", self.name)
+    self.needsRefresh = true
+    updateStatusIndicator("refreshing")
     
+    local connections = buildConnectionTable(self.connectionIndex)
     sendOSC('/live/song/get/track_names', nil, connections)
 end
 
-function onReceiveOSC(message, connections)
-    local instance = self.tempInstance or parseGroupName(self.name)
-    local expectedConnection = getConnectionIndex(instance)
+function updateStatusIndicator(status)
+    if not self.children.status_indicator then return end
     
-    if not connections[expectedConnection] then return end
+    local colors = {
+        refreshing = {1, 1, 0},     -- Yellow
+        ok = {0, 1, 0},             -- Green
+        error = {1, 0, 0},          -- Red
+        stale = {1, 0.5, 0}         -- Orange
+    }
     
-    local path = message[1]
-    if path ~= '/live/song/get/track_names' then return end
-    
-    local trackName = self.name:match("^%w+_(.+)$") or self.name
-    local arguments = message[2]
-    
-    for i = 1, #arguments do
-        if arguments[i].value == trackName then
-            local trackNumber = i - 1
-            self.tag = instance .. ":" .. trackNumber
-            
-            local targetConnections = buildConnectionTable(expectedConnection)
-            
-            -- Start listeners
-            sendOSC('/live/track/start_listen/volume', {trackNumber}, targetConnections)
-            sendOSC('/live/track/start_listen/output_meter_level', {trackNumber}, targetConnections)
-            sendOSC('/live/track/start_listen/mute', {trackNumber}, targetConnections)
-            sendOSC('/live/track/start_listen/panning', {trackNumber}, targetConnections)
-            
-            -- Update label
-            self.children["fdr_label"].values.text = arguments[i].value:match("(%w+)(.*)")
-            self.tempInstance = nil
-            return
+    self.children.status_indicator.color = colors[status] or {0.5, 0.5, 0.5}
+end
+
+function onNotify(param)
+    if param == "refresh" then
+        refreshTrackMapping()
+    end
+end
+
+function update()
+    -- Check data age
+    if self.lastVerified > 0 then
+        local age = getMillis() - self.lastVerified
+        if age > 60000 then  -- 1 minute
+            updateStatusIndicator("stale")
         end
     end
-    
-    self.children["fdr_label"].values.text = "???"
 end
 ```
 
-### Generic Child Control Script
+### Child Control with Parent Validation
 ```lua
+function getParentInfo()
+    local p = self.parent
+    if not p then 
+        print("Error: No parent")
+        return nil 
+    end
+    
+    if not p.trackNumber or not p.connectionIndex then
+        print("Error: Parent not initialized")
+        return nil
+    end
+    
+    return {
+        trackNumber = p.trackNumber,
+        connectionIndex = p.connectionIndex,
+        instance = p.instance
+    }
+end
+
 function onValueChanged(key)
-    if key == "[value_key]" then  -- Replace with actual key
-        local parentTag = self.parent.tag
-        if not parentTag then return end
+    if key == "x" and self.values.touch then
+        local info = getParentInfo()
+        if not info then return end
         
-        local instance, trackNumber = parentTag:match("([^:]+):(.+)")
-        if not instance or not trackNumber then return end
-        
-        local connectionIndex = getConnectionIndex(instance)
-        local connections = buildConnectionTable(connectionIndex)
-        
-        sendOSC("/live/track/" .. trackNumber .. "/[parameter]", 
-                {self.values[key]}, connections)
+        local connections = buildConnectionTable(info.connectionIndex)
+        sendOSC("/live/track/" .. info.trackNumber .. "/volume", 
+                {self.values.x}, connections)
     end
 end
 
 function onReceiveOSC(message, connections)
-    local parentTag = self.parent.tag
-    if not parentTag then return end
+    local info = getParentInfo()
+    if not info then return end
     
-    local instance, trackNumber = parentTag:match("([^:]+):(.+)")
-    if not instance or not trackNumber then return end
+    -- Filter by connection
+    if not connections[info.connectionIndex] then return end
     
-    local expectedConnection = getConnectionIndex(instance)
-    if not connections[expectedConnection] then return end
-    
+    -- Process message
     local path = message[1]
-    local expectedPath = "/live/track/" .. trackNumber .. "/[parameter]"
+    local expectedPath = "/live/track/" .. info.trackNumber .. "/volume"
     
     if path == expectedPath and message[2][1] then
-        self.values.[value_key] = message[2][1].value
+        self.values.x = message[2][1].value
     end
 end
 ```
 
 ## Testing Strategy
 
-### Connection Test Script
-Create a test button that verifies routing:
-```lua
-function onValueChanged(key)
-    if key == "x" and self.values.x == 1 then
-        -- Test all configurations
-        local instances = {"band", "master"}
-        
-        for _, instance in ipairs(instances) do
-            local connIdx = getConnectionIndex(instance)
-            print(instance .. " uses connection " .. connIdx)
-            
-            -- Send test message
-            local connections = buildConnectionTable(connIdx)
-            sendOSC("/test/" .. instance, {"ping"}, connections)
-        end
-    end
-end
-```
+### Manual Refresh Test
+1. Move tracks in Ableton
+2. Press refresh button
+3. Verify correct track control restored
+4. Check status indicators
 
-### Debug Helper
-Add to any script for troubleshooting:
-```lua
-function debugConnection(message, connections)
-    print("Message from connections:")
-    for i, active in ipairs(connections) do
-        if active then
-            print("  Connection " .. i .. ": Active")
-        end
-    end
-end
-```
+### Auto-Refresh Test
+1. Enable auto-refresh
+2. Move tracks in Ableton
+3. Wait for refresh cycle
+4. Verify automatic recovery
+
+### Stress Test
+1. Rapid track reordering
+2. Multiple simultaneous refreshes
+3. Connection loss/recovery
+4. Performance monitoring
 
 ## Configuration Management
 
-### Best Practices
-1. **Naming Convention**: Always use `connection_[instance]` format
-2. **Documentation**: Add labels next to config objects explaining purpose
-3. **Validation**: Config objects should show red if invalid value
-4. **Backup**: Screenshot configuration before major changes
+### Visual Feedback System
+- **Green**: Connected and verified
+- **Yellow**: Refreshing
+- **Orange**: Data may be stale (>1 minute)
+- **Red**: Track not found or error
 
-### Advanced Configuration
-For complex setups, consider a configuration panel:
-```
-Configuration Panel
-├── Band Section
-│   ├── Connection: [1] [2] [3] ...
-│   ├── IP: [192.168.1.100]
-│   └── Port: [11000]
-│
-└── Master Section
-    ├── Connection: [1] [2] [3] ...
-    ├── IP: [192.168.1.101]
-    └── Port: [11001]
-```
+### User Controls
+- **Per-group refresh button**: Manual refresh
+- **Global refresh button**: Refresh all groups
+- **Auto-refresh toggle**: Enable/disable automatic refresh
+- **Auto-refresh interval**: Configurable timing
 
-## Success Criteria
-- [ ] No manual connection selection per control
-- [ ] Visual indication of routing in group names
-- [ ] Easy to change connections via config objects
-- [ ] No cross-talk between instances
-- [ ] Performance comparable to original
-- [ ] Can add new instances without code changes
+## Benefits of This Approach
+✅ **Robust against track reordering** with refresh mechanisms  
+✅ **Visual feedback** shows connection status  
+✅ **User control** over refresh timing  
+✅ **No hardcoded indices** - uses configuration objects  
+✅ **Graceful degradation** - works even if refresh fails  
+✅ **Performance conscious** - refresh only when needed  
 
 ## Risk Mitigation
-1. **Test thoroughly** at each phase
-2. **Keep backups** of working configuration
-3. **Document issues** as they arise
-4. **Have rollback plan** ready
-5. **Test under real performance conditions**
+1. **Always store both name and index**
+2. **Validate parent data before use**
+3. **Provide manual refresh option**
+4. **Visual feedback for all states**
+5. **Test thoroughly with track reordering**
+6. **Document refresh procedures for users**
 
 ## Next Steps
-1. Review and approve phase document
-2. Set up test environment (Phase 0)
-3. Begin Phase 1 with single group test
+1. Review and approve updated phase document
+2. Implement Phase 0 (preparation)
+3. Test Phase 1 with single group
 4. Iterate based on findings
-5. Proceed through phases systematically
+5. Roll out incrementally through phases


### PR DESCRIPTION
## Summary
Adding phase documentation for selective connection routing feature. This document outlines the approach for allowing different faders to communicate with separate Ableton instances (band and master) while handling AbletonOSC limitations.

## Changes
- [x] Add phase document outlining implementation options
- [x] Corrected approach based on actual TouchOSC capabilities
- [x] Added recommended prefix-based group naming solution
- [x] Added detailed OSC receiving behavior and connection filtering
- [x] Created complete implementation examples and migration guide
- [x] Incorporated AbletonOSC limitations and track reordering solutions
- [x] Added refresh mechanisms (manual, auto, visual feedback)

## Key Features

### Connection Routing
- `band_Hand 1 #` → Routes to band Ableton instance
- `master_Hand 1 #` → Routes to master Ableton instance
- Configuration objects define connection mappings

### Track Reordering Handling
- **Manual refresh buttons** per group and globally
- **Auto-refresh option** with configurable interval
- **Visual feedback system** (green=OK, yellow=refreshing, orange=stale, red=error)
- **Stores both track name and index** for robustness

### Implementation Strategy
- 7 phases for incremental rollout
- Complete script templates with validation
- Testing protocols at each phase
- Rollback procedures

## Documentation
- `/docs/01-selective-connection-routing-phase.md` - Complete implementation plan
- Includes AbletonOSC capabilities and limitations
- Working code examples for all components
- Migration guide with step-by-step instructions

## Benefits
- ✅ Minimal changes to existing codebase
- ✅ Visual clarity in TouchOSC editor
- ✅ Robust against track reordering
- ✅ User control over refresh timing
- ✅ No manual configuration per control needed
- ✅ Graceful degradation if refresh fails

## Next Steps
After this PR is merged:
1. Implement Phase 0 (preparation and setup)
2. Test Phase 1 with single group and refresh mechanisms
3. Iterate through phases based on test results
4. Full rollout with monitoring