### PR TITLE
Fix: Meter and labels remain non-interactive when group is mapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Group interactivity bug - meters and labels now remain non-interactive when group is mapped
+  - Simplified code to only handle controls that need interactivity changes
+  - Removed unnecessary code that was setting non-interactive states
+  - Let TouchOSC editor handle non-interactive state for meters/labels
 - Refresh All button now properly reassigns groups when tracks are renumbered in Ableton
   - Implemented registration system where groups self-register with document script
   - Fixed issue where refresh would find 0 groups after initial mapping

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -2,41 +2,39 @@
 
 ## CRITICAL CURRENT STATE
 **⚠️ EXACTLY WHERE WE ARE RIGHT NOW:**
-- [x] Currently working on: Fix group interactivity bug - IMPLEMENTED
-- [ ] Waiting for: User to test the fix
+- [x] Currently working on: Fix group interactivity bug - SIMPLIFIED & IMPLEMENTED
+- [ ] Waiting for: User to test the simplified fix
 - [ ] Blocked by: None
 
 ## Current Task: Fix Group Interactivity Bug
 **Started**: 2025-07-05  
 **Branch**: feature/fix-group-interactivity
 **Status**: IMPLEMENTED_NOT_TESTED
-**PR**: #16 - Created, waiting for testing
+**PR**: #16 - Updated with simplified solution
 
 ### Problem Description:
 When a group is enabled/mapped, the meter control was incorrectly becoming interactive along with the fader, mute, and pan controls. Meter and labels should always remain non-interactive.
 
-### Solution Implemented:
-Modified `setGroupEnabled` function in `group_init.lua` to:
-1. Split controls into two categories:
-   - Interactive controls: fader, mute, pan (change with group state)
-   - Non-interactive controls: meter, track_label, db (always non-interactive)
-2. Added explicit logic to keep non-interactive controls non-interactive
-3. Added debug logging to track interactivity changes
+### Solution Implemented (v1.16.4):
+Simplified approach - only handle controls that need to change:
+1. Removed all code that sets controls to non-interactive
+2. Only set interactivity for: fader, mute, pan
+3. Let TouchOSC editor handle non-interactive state for meters/labels
+4. Much cleaner, simpler code
 
 ### Changes Made:
-1. ✅ **group_init.lua v1.16.3**:
-   - Fixed `setGroupEnabled` function
-   - Split control lists into interactive and non-interactive
-   - Added logging for interactivity changes
+1. ✅ **group_init.lua v1.16.4**:
+   - Simplified `setGroupEnabled` function
+   - Only handles fader, mute, pan interactivity
+   - Removed unnecessary non-interactive code
    - **DEBUG = 0** (production ready)
 
 ### Testing Required:
+- [ ] Ensure meters/labels are non-interactive in TouchOSC editor
 - [ ] Load TouchOSC with updated script
-- [ ] Verify meters and labels are non-interactive initially
 - [ ] Map a group to a track in Ableton
 - [ ] Verify fader, mute, pan become interactive
 - [ ] Verify meter and labels remain non-interactive
-- [ ] Test with DEBUG=1 to see logging
 
 ## Previous Tasks Completed:
 1. **Refresh Track Renumbering Fix** - PR #15 ready to merge (from previous thread)
@@ -45,6 +43,6 @@ Modified `setGroupEnabled` function in `group_init.lua` to:
 4. **Dead Code Removal** - Completed in PR #12
 
 ## Next Steps:
-1. User tests the interactivity fix
+1. User tests the simplified interactivity fix
 2. If successful, merge PR #16
 3. Check if PR #15 should still be merged

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -1,40 +1,40 @@
 # Thread Progress Tracking
 
 ## CRITICAL CURRENT STATE
-**⚠️ EXACTLY WHERE WE ARE RIGHT NOW:**
-- [x] Currently working on: Fix group interactivity bug - SIMPLIFIED & IMPLEMENTED
-- [ ] Waiting for: User to test the simplified fix
-- [ ] Blocked by: None
+**✅ READY FOR MERGE - TESTED & APPROVED:**
+- [x] Currently working on: Fix group interactivity bug - COMPLETE
+- [x] Testing successful - simplified solution works correctly
+- [x] CHANGELOG.md updated
+- [x] All scripts have DEBUG = 0 for production
+- [ ] Waiting for: User to merge PR #16
 
-## Current Task: Fix Group Interactivity Bug
+## Current Task: Fix Group Interactivity Bug - COMPLETE
 **Started**: 2025-07-05  
 **Branch**: feature/fix-group-interactivity
-**Status**: IMPLEMENTED_NOT_TESTED
-**PR**: #16 - Updated with simplified solution
+**Status**: PRODUCTION_READY
+**PR**: #16 - Ready to merge
 
-### Problem Description:
-When a group is enabled/mapped, the meter control was incorrectly becoming interactive along with the fader, mute, and pan controls. Meter and labels should always remain non-interactive.
+### Solution Summary:
+Simplified the interactivity handling to only set controls that need to become interactive (fader, mute, pan). Removed unnecessary code that was setting non-interactive states. Let TouchOSC editor handle non-interactive state for meters and labels.
 
-### Solution Implemented (v1.16.4):
-Simplified approach - only handle controls that need to change:
-1. Removed all code that sets controls to non-interactive
-2. Only set interactivity for: fader, mute, pan
-3. Let TouchOSC editor handle non-interactive state for meters/labels
-4. Much cleaner, simpler code
-
-### Changes Made:
+### Final Changes:
 1. ✅ **group_init.lua v1.16.4**:
    - Simplified `setGroupEnabled` function
    - Only handles fader, mute, pan interactivity
    - Removed unnecessary non-interactive code
-   - **DEBUG = 0** (production ready)
+   - **DEBUG = 0** (verified)
 
-### Testing Required:
-- [ ] Ensure meters/labels are non-interactive in TouchOSC editor
-- [ ] Load TouchOSC with updated script
-- [ ] Map a group to a track in Ableton
-- [ ] Verify fader, mute, pan become interactive
-- [ ] Verify meter and labels remain non-interactive
+### Testing Results:
+- ✅ Meters and labels remain non-interactive when group is mapped
+- ✅ Fader, mute, pan become interactive correctly
+- ✅ Clean, simple solution tested successfully
+
+### Production Ready Checklist:
+- ✅ All scripts have DEBUG = 0
+- ✅ CHANGELOG.md updated
+- ✅ PR description updated with simplified approach
+- ✅ Testing successful
+- ✅ No DEBUG flags or development artifacts remain
 
 ## Previous Tasks Completed:
 1. **Refresh Track Renumbering Fix** - PR #15 ready to merge (from previous thread)
@@ -43,6 +43,6 @@ Simplified approach - only handle controls that need to change:
 4. **Dead Code Removal** - Completed in PR #12
 
 ## Next Steps:
-1. User tests the simplified interactivity fix
-2. If successful, merge PR #16
+1. **Merge PR #16** to main branch
+2. Close related issue if any
 3. Check if PR #15 should still be merged

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -1,68 +1,50 @@
 # Thread Progress Tracking
 
 ## CRITICAL CURRENT STATE
-**✅ READY FOR MERGE - PRODUCTION READY:**
-- [x] Currently working on: COMPLETE - Fix refresh all button track renumbering issue
-- [x] All scripts have DEBUG = 0 for production (VERIFIED)
-- [x] Testing confirmed successful
-- [x] Final pre-merge checks completed
-- [ ] Waiting for: User to merge PR #15
+**⚠️ EXACTLY WHERE WE ARE RIGHT NOW:**
+- [x] Currently working on: Fix group interactivity bug - IMPLEMENTED
+- [ ] Waiting for: User to test the fix
+- [ ] Blocked by: None
 
-## Current Task: Fix Refresh Track Renumbering - COMPLETE
-**Started**: 2025-07-05
-**Branch**: feature/fix-refresh-track-renumbering  
-**Status**: PRODUCTION_READY
-**PR**: #15 - Ready to merge
+## Current Task: Fix Group Interactivity Bug
+**Started**: 2025-07-05  
+**Branch**: feature/fix-group-interactivity
+**Status**: IMPLEMENTED_NOT_TESTED
+**PR**: #16 - Created, waiting for testing
 
-### Solution Summary:
-Implemented a registration system where track groups self-register with the document script during initialization. This avoids the issues with searching TouchOSC's control hierarchy and ensures refresh works regardless of tag changes.
+### Problem Description:
+When a group is enabled/mapped, the meter control was incorrectly becoming interactive along with the fader, mute, and pan controls. Meter and labels should always remain non-interactive.
 
-### Final Changes:
-1. ✅ **group_init.lua v1.16.2**:
-   - Each group registers itself with document script on init
-   - Properly handles clear_mapping and refresh_tracks
-   - Resets tag and notifies children on clear
-   - **DEBUG = 0** (verified)
+### Solution Implemented:
+Modified `setGroupEnabled` function in `group_init.lua` to:
+1. Split controls into two categories:
+   - Interactive controls: fader, mute, pan (change with group state)
+   - Non-interactive controls: meter, track_label, db (always non-interactive)
+2. Added explicit logic to keep non-interactive controls non-interactive
+3. Added debug logging to track interactivity changes
 
-2. ✅ **document_script.lua v2.8.7**:
-   - Maintains registry of track groups
-   - No searching required - groups self-register
-   - 100ms delay between clear and refresh operations
-   - **DEBUG = 0** (verified)
+### Changes Made:
+1. ✅ **group_init.lua v1.16.3**:
+   - Fixed `setGroupEnabled` function
+   - Split control lists into interactive and non-interactive
+   - Added logging for interactivity changes
+   - **DEBUG = 0** (production ready)
 
-3. ✅ **fader_script.lua v2.5.3**:
-   - Handles mapping_cleared notification
-   - Cancels animations when mapping is cleared
-   - Always reads fresh track info from parent tag
-   - **DEBUG = 0** (verified)
-
-4. ✅ **Additional scripts verified**:
-   - global_refresh_button.lua v1.5.1 - **DEBUG = 0**
-   - mute_button.lua v2.0.1 - **DEBUG = 0**
-   - meter_script.lua v2.4.1 - **DEBUG = 0**
-   - All other track scripts - **DEBUG = 0**
-
-### Testing Results:
-- ✅ Groups register successfully on startup
-- ✅ Refresh finds and clears all groups (not 0)
-- ✅ Track renumbering works correctly (track 7 → track 6 confirmed)
-- ✅ Faders control correct tracks after refresh
-- ✅ No controls stuck on wrong tracks
-
-### Production Ready Checklist:
-- ✅ All scripts have DEBUG = 0 (verified 2025-07-05)
-- ✅ CHANGELOG.md updated
-- ✅ Documentation complete
-- ✅ PR description updated
-- ✅ Testing successful
-- ✅ No DEBUG flags or development artifacts remain
+### Testing Required:
+- [ ] Load TouchOSC with updated script
+- [ ] Verify meters and labels are non-interactive initially
+- [ ] Map a group to a track in Ableton
+- [ ] Verify fader, mute, pan become interactive
+- [ ] Verify meter and labels remain non-interactive
+- [ ] Test with DEBUG=1 to see logging
 
 ## Previous Tasks Completed:
-1. **Notify Usage Analysis** - Merged PR #12
-2. **Remove Centralized Logging** - Merged PR #11
-3. **Dead Code Removal** - Completed in PR #12
+1. **Refresh Track Renumbering Fix** - PR #15 ready to merge (from previous thread)
+2. **Notify Usage Analysis** - Merged PR #12
+3. **Remove Centralized Logging** - Merged PR #11
+4. **Dead Code Removal** - Completed in PR #12
 
 ## Next Steps:
-1. **Merge PR #15** to main branch
-2. Close issue related to track renumbering
-3. Update main branch documentation if needed
+1. User tests the interactivity fix
+2. If successful, merge PR #16
+3. Check if PR #15 should still be merged

--- a/scripts/track/group_init.lua
+++ b/scripts/track/group_init.lua
@@ -1,9 +1,9 @@
 -- TouchOSC Group Initialization Script with Auto Track Type Detection
--- Version: 1.16.2
--- Changed: Register group with document script on init for reliable refresh
+-- Version: 1.16.3
+-- Changed: Fix interactivity - meter and labels remain non-interactive when group is mapped
 
 -- Version constant
-local SCRIPT_VERSION = "1.16.2"
+local SCRIPT_VERSION = "1.16.3"
 
 -- Debug flag - set to 1 to enable logging
 local DEBUG = 0
@@ -126,15 +126,28 @@ local function setGroupEnabled(enabled, silent)
     
     local childCount = 0
     
-    -- Only check for controls we know exist (fixed db_label -> db)
-    local controlsToCheck = {"fader", "mute", "pan", "meter", "track_label", "db"}
+    -- Only these controls should become interactive when group is mapped
+    local interactiveControls = {"fader", "mute", "pan"}
     
-    for _, name in ipairs(controlsToCheck) do
+    -- These controls should always remain non-interactive
+    local nonInteractiveControls = {"meter", "track_label", "db"}
+    
+    -- Set interactivity for controls that should change
+    for _, name in ipairs(interactiveControls) do
         local child = getChild(self, name)
-        if child and name ~= "status_indicator" and name ~= "connection_label" then
-            -- ONLY CHANGE INTERACTIVITY - NO VISUAL CHANGES!
+        if child then
             child.interactive = enabled
             childCount = childCount + 1
+            log("Set " .. name .. " interactive: " .. tostring(enabled))
+        end
+    end
+    
+    -- Ensure non-interactive controls stay non-interactive
+    for _, name in ipairs(nonInteractiveControls) do
+        local child = getChild(self, name)
+        if child then
+            child.interactive = false
+            log("Keeping " .. name .. " non-interactive")
         end
     end
     

--- a/scripts/track/group_init.lua
+++ b/scripts/track/group_init.lua
@@ -1,9 +1,9 @@
 -- TouchOSC Group Initialization Script with Auto Track Type Detection
--- Version: 1.16.3
--- Changed: Fix interactivity - meter and labels remain non-interactive when group is mapped
+-- Version: 1.16.4
+-- Changed: Simplified interactivity - only set fader, mute, pan as interactive
 
 -- Version constant
-local SCRIPT_VERSION = "1.16.3"
+local SCRIPT_VERSION = "1.16.4"
 
 -- Debug flag - set to 1 to enable logging
 local DEBUG = 0
@@ -110,7 +110,7 @@ local function updateStatusIndicator()
     end
 end
 
--- Enable/disable all controls in the group - ONLY INTERACTIVITY
+-- Enable/disable interactive controls in the group
 local function setGroupEnabled(enabled, silent)
     -- Skip if state hasn't changed to prevent spam
     if lastEnabledState == enabled then
@@ -124,30 +124,13 @@ local function setGroupEnabled(enabled, silent)
         return
     end
     
-    local childCount = 0
-    
-    -- Only these controls should become interactive when group is mapped
+    -- Only set interactivity for controls that need it
     local interactiveControls = {"fader", "mute", "pan"}
     
-    -- These controls should always remain non-interactive
-    local nonInteractiveControls = {"meter", "track_label", "db"}
-    
-    -- Set interactivity for controls that should change
     for _, name in ipairs(interactiveControls) do
         local child = getChild(self, name)
         if child then
             child.interactive = enabled
-            childCount = childCount + 1
-            log("Set " .. name .. " interactive: " .. tostring(enabled))
-        end
-    end
-    
-    -- Ensure non-interactive controls stay non-interactive
-    for _, name in ipairs(nonInteractiveControls) do
-        local child = getChild(self, name)
-        if child then
-            child.interactive = false
-            log("Keeping " .. name .. " non-interactive")
         end
     end
     


### PR DESCRIPTION
## Bug Fix: Group Interactivity Issue

### Problem
When a group is enabled/mapped, the meter control was incorrectly becoming interactive along with the fader, mute, and pan controls. According to requirements, meter and labels should always remain non-interactive.

### Solution (Simplified)
Modified the `setGroupEnabled` function in `group_init.lua` to only handle controls that need to become interactive:
- **Interactive controls**: fader, mute, pan
- Removed all code that sets controls to non-interactive
- Let TouchOSC editor handle the non-interactive state for meters and labels

### Changes
- Version bump: 1.16.2 → 1.16.4
- Simplified code to only set interactivity for fader, mute, pan
- Removed unnecessary code that was setting non-interactive states
- Cleaner, more maintainable solution

### Testing Instructions
1. Ensure meters and labels are set to non-interactive in TouchOSC editor
2. Load TouchOSC with the updated script
3. Map a group to a track in Ableton
4. Verify that:
   - Fader, mute, and pan become interactive ✓
   - Meter and labels remain non-interactive ✓

### Files Changed
- `scripts/track/group_init.lua` - Simplified interactivity logic