### PR TITLE
Restore pan button color change and double touch functionality

### DIFF
--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -1,48 +1,47 @@
 # Thread Progress Tracking
 
 ## CRITICAL CURRENT STATE
-**✅ READY FOR MERGE - TESTED & APPROVED:**
-- [x] Currently working on: Fix group interactivity bug - COMPLETE
-- [x] Testing successful - simplified solution works correctly
-- [x] CHANGELOG.md updated
-- [x] All scripts have DEBUG = 0 for production
-- [ ] Waiting for: User to merge PR #16
+**⚠️ EXACTLY WHERE WE ARE RIGHT NOW:**
+- [x] Currently working on: Restoring pan control functionality
+- [ ] Waiting for: User to test the restored features
+- [ ] Blocked by: None
 
-## Current Task: Fix Group Interactivity Bug - COMPLETE
+## Current Task: Restore Pan Control Features
 **Started**: 2025-07-05  
-**Branch**: feature/fix-group-interactivity
-**Status**: PRODUCTION_READY
-**PR**: #16 - Ready to merge
+**Branch**: feature/restore-pan-functionality
+**Status**: IMPLEMENTED_NOT_TESTED
+**PR**: #17 - Ready for testing
 
-### Solution Summary:
-Simplified the interactivity handling to only set controls that need to become interactive (fader, mute, pan). Removed unnecessary code that was setting non-interactive states. Let TouchOSC editor handle non-interactive state for meters and labels.
+### Problem Identified:
+User reported that pan button lost its color change and double touch functionality between versions.
 
-### Final Changes:
-1. ✅ **group_init.lua v1.16.4**:
-   - Simplified `setGroupEnabled` function
-   - Only handles fader, mute, pan interactivity
-   - Removed unnecessary non-interactive code
-   - **DEBUG = 0** (verified)
+### Solution Implemented:
+Restored missing functionality in pan_control.lua v1.6.0:
+1. ✅ **Color change based on pan position**:
+   - Gray when centered (within 0.02 tolerance)
+   - Yellow when panned left or right
+   - Uses `updateVisualState()` function
+2. ✅ **Double touch to center**:
+   - Double tap detection with 500ms timeout
+   - Smooth animation back to center
+   - Animation speed configurable
 
-### Testing Results:
-- ✅ Meters and labels remain non-interactive when group is mapped
-- ✅ Fader, mute, pan become interactive correctly
-- ✅ Clean, simple solution tested successfully
-
-### Production Ready Checklist:
-- ✅ All scripts have DEBUG = 0
-- ✅ CHANGELOG.md updated
-- ✅ PR description updated with simplified approach
-- ✅ Testing successful
-- ✅ No DEBUG flags or development artifacts remain
+### Testing Required:
+- [ ] Pan control shows gray when centered
+- [ ] Pan control shows yellow when panned
+- [ ] Double touch centers pan smoothly
+- [ ] Works with regular tracks
+- [ ] Works with return tracks
+- [ ] No performance impact
 
 ## Previous Tasks Completed:
-1. **Refresh Track Renumbering Fix** - PR #15 ready to merge (from previous thread)
-2. **Notify Usage Analysis** - Merged PR #12
-3. **Remove Centralized Logging** - Merged PR #11
-4. **Dead Code Removal** - Completed in PR #12
+1. **Group Interactivity Bug Fix** - PR #16 ready to merge (from previous thread)
+2. **Refresh Track Renumbering Fix** - PR #15 ready to merge (from previous thread)
+3. **Notify Usage Analysis** - Merged PR #12
+4. **Remove Centralized Logging** - Merged PR #11
+5. **Dead Code Removal** - Completed in PR #12
 
 ## Next Steps:
-1. **Merge PR #16** to main branch
-2. Close related issue if any
-3. Check if PR #15 should still be merged
+1. **Test pan control restoration** with both color and double touch
+2. Merge PR #17 if testing successful
+3. Check if PRs #15 and #16 should still be merged


### PR DESCRIPTION
This PR restores missing pan control functionality that was lost during development:

## Features Restored
- ✅ **Color change based on pan position**
  - Gray when centered (within tolerance)
  - Yellow when panned left or right
- ✅ **Double touch to center functionality**
  - Double tap the pan control to smoothly animate back to center
  - 500ms timeout for double touch detection
  - Smooth animation with configurable speed

## Changes
- `pan_control.lua` v1.5.1 → v1.6.0
  - Added `updateVisualState()` function for color management
  - Added double touch detection with configurable timeout
  - Added smooth centering animation with `update()` function
  - Added tolerance for center detection (0.02 units)
  - Maintains all existing functionality

## Technical Details
- Color indication uses TouchOSC's Color API
- Double touch uses time-based detection (500ms window)
- Animation runs at frame rate with adjustable speed
- Color tolerance prevents flickering at center position

## Testing Required
1. Test pan control shows gray when centered (±0.02 tolerance)
2. Test pan control shows yellow when panned left or right  
3. Test double touch returns pan to center with smooth animation
4. Test color updates immediately when manually panning
5. Test with both regular tracks and return tracks
6. Verify no performance impact from update() function