### PR TITLE
Restore missing pan control features (color change and double-tap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Restored missing pan control features (v1.5.3)
+  - Color change functionality: gray when centered, cyan when off-center
+  - Double-tap to center functionality with 300ms detection window
+  - Optimized performance by removing continuous update() calls
+  - Color changes now event-driven in onValueChanged()
 - Group interactivity bug - meters and labels now remain non-interactive when group is mapped
   - Simplified code to only handle controls that need interactivity changes
   - Removed unnecessary code that was setting non-interactive states

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -2,52 +2,49 @@
 
 ## CRITICAL CURRENT STATE
 **⚠️ WORKING ON PAN CONTROL RESTORATION:**
-- [x] Currently working on: Restored missing pan control features (color change & double-tap)
-- [ ] Waiting for: User to test implementation in TouchOSC
+- [x] Currently working on: Optimized pan control performance by removing update()
+- [ ] Waiting for: User to test optimized implementation in TouchOSC
 - [ ] Branch: feature/restore-pan-features
-- [ ] PR #18 created and ready for testing
+- [ ] PR #18 - Implementation optimized, awaiting testing
 
 ## Current Task: Restore Missing Pan Control Features
 **Started**: 2025-07-05  
 **Branch**: feature/restore-pan-features
 **Status**: IMPLEMENTED_NOT_TESTED
-**PR**: #18 - Implementation complete, awaiting testing
+**PR**: #18 - Implementation optimized, awaiting testing
 
 ### Changes Made:
-1. ✅ **pan_control.lua v1.5.1 → v1.5.2**:
-   - Restored color change functionality
-   - Added COLOR_CENTERED and COLOR_OFF_CENTER constants
-   - Restored update() function for visual feedback
-   - Restored double-tap detection logic
-   - Added DOUBLE_TAP_DELAY constant (300ms)
-   - Integrated double-tap handling in onValueChanged()
-   - Set initial color in init()
-   - **DEBUG = 0** (production ready)
+1. ✅ **pan_control.lua v1.5.2 → v1.5.3**:
+   - **OPTIMIZATION**: Removed update() function for better performance
+   - Color changes now handled in onValueChanged() only when value actually changes
+   - No continuous update() calls - more efficient
+   - All functionality preserved (color change & double-tap)
+   - Added updateColor() helper function
+   - Color updated in all relevant places:
+     - When x value changes
+     - On double-tap
+     - When receiving OSC updates
+     - On track changes
 
-### Features Restored:
+### Features Status:
 1. **Color Change**: 
    - Gray (#646464) when pan is centered
    - Cyan (#34C1DC) when pan is off-center
-   - Uses update() function to continuously check position
+   - Now updates only on value change (more efficient)
    - 0.01 threshold to avoid flickering
 
 2. **Double-tap to Center**:
    - 300ms time window for double-tap detection
    - Centers pan to 0.5 (TouchOSC) / 0 (Ableton)
    - Sends OSC message to update Ableton
-   - Logs double-tap detection (when DEBUG=1)
+   - Updates color immediately on double-tap
 
-### Implementation Analysis:
-- Compared with old v1.4.1 code provided by user
-- Identified exactly 2 missing features (color change & double-tap)
-- Current version has additional improvements:
-  - Better state management (isTouching flag)
-  - Connection routing support
-  - Notify handlers for track changes
-  - Touch state tracking to prevent value jumps
-- Other scripts checked - no missing features found
+3. **Logger Functionality**:
+   - Intentionally removed (user confirmed)
+   - Focus on performance and simplicity
 
 ### Testing Checklist:
+- [ ] Verify version 1.5.3 loads in logs
 - [ ] Verify pan color is gray when centered
 - [ ] Verify pan color is cyan when off-center
 - [ ] Test double-tap centers the pan to 0.5
@@ -55,8 +52,7 @@
 - [ ] Test with regular tracks
 - [ ] Test with return tracks
 - [ ] Verify multi-connection support works
-- [ ] Check no performance issues with update() function
-- [ ] Confirm version 1.5.2 loads in logs
+- [ ] Confirm no performance issues (update() removed)
 
 ## Previous PRs Pending:
 1. **PR #16** - Group Interactivity Fix (ready to merge)
@@ -69,15 +65,14 @@
    - Fixes refresh when tracks renumbered in Ableton
 
 ## Next Steps:
-1. User tests restored pan features in TouchOSC
+1. User tests optimized pan features in TouchOSC
 2. If issues found, fix and update version
 3. Update CHANGELOG.md after testing success
 4. Merge PR #18 after approval
 5. Consider merging pending PRs #15 and #16
 
 ## Session Notes:
-- User reported pan control lost color change and double-tap functionality
-- Old working version (v1.4.1) was provided as reference
-- Implementation kept simple and performant
-- All project rules followed (local logging, Color constructor, etc.)
-- No other scripts were missing features
+- User confirmed logger functionality was intentionally removed
+- Optimized for performance by removing continuous update() calls
+- Color changes now event-driven (onValueChanged) instead of polling
+- All features preserved with better performance

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -1,78 +1,65 @@
 # Thread Progress Tracking
 
 ## CRITICAL CURRENT STATE
-**⚠️ WORKING ON PAN CONTROL RESTORATION:**
-- [x] Currently working on: Optimized pan control performance by removing update()
-- [ ] Waiting for: User to test optimized implementation in TouchOSC
+**⚠️ PAN CONTROL RESTORATION COMPLETE:**
+- [x] Currently working on: Pan control features restored and tested
+- [x] Testing completed successfully - all features working
+- [ ] Ready to merge PR #18
 - [ ] Branch: feature/restore-pan-features
-- [ ] PR #18 - Implementation optimized, awaiting testing
 
 ## Current Task: Restore Missing Pan Control Features
 **Started**: 2025-07-05  
 **Branch**: feature/restore-pan-features
-**Status**: IMPLEMENTED_NOT_TESTED
-**PR**: #18 - Implementation optimized, awaiting testing
+**Status**: TESTING_COMPLETE ✅
+**PR**: #18 - Ready to merge!
 
-### Changes Made:
-1. ✅ **pan_control.lua v1.5.2 → v1.5.3**:
-   - **OPTIMIZATION**: Removed update() function for better performance
-   - Color changes now handled in onValueChanged() only when value actually changes
-   - No continuous update() calls - more efficient
-   - All functionality preserved (color change & double-tap)
-   - Added updateColor() helper function
-   - Color updated in all relevant places:
-     - When x value changes
-     - On double-tap
-     - When receiving OSC updates
-     - On track changes
+### Final Implementation:
+1. ✅ **pan_control.lua v1.5.3**:
+   - Restored color change functionality (gray/cyan)
+   - Restored double-tap to center functionality
+   - Optimized performance - removed continuous update() calls
+   - Color changes now event-driven
+   - All features tested and working
 
-### Features Status:
-1. **Color Change**: 
-   - Gray (#646464) when pan is centered
-   - Cyan (#34C1DC) when pan is off-center
-   - Now updates only on value change (more efficient)
-   - 0.01 threshold to avoid flickering
+### Testing Results: ✅
+- ✅ Version 1.5.3 loads successfully
+- ✅ Pan color is gray when centered
+- ✅ Pan color is cyan when off-center
+- ✅ Double-tap centers the pan to 0.5
+- ✅ OSC message sent to Ableton on double-tap
+- ✅ Works with regular tracks
+- ✅ Works with return tracks
+- ✅ Multi-connection support works
+- ✅ No performance issues (update() removed)
 
-2. **Double-tap to Center**:
-   - 300ms time window for double-tap detection
-   - Centers pan to 0.5 (TouchOSC) / 0 (Ableton)
-   - Sends OSC message to update Ableton
-   - Updates color immediately on double-tap
-
-3. **Logger Functionality**:
-   - Intentionally removed (user confirmed)
-   - Focus on performance and simplicity
-
-### Testing Checklist:
-- [ ] Verify version 1.5.3 loads in logs
-- [ ] Verify pan color is gray when centered
-- [ ] Verify pan color is cyan when off-center
-- [ ] Test double-tap centers the pan to 0.5
-- [ ] Confirm OSC message sent to Ableton on double-tap
-- [ ] Test with regular tracks
-- [ ] Test with return tracks
-- [ ] Verify multi-connection support works
-- [ ] Confirm no performance issues (update() removed)
-
-## Previous PRs Pending:
-1. **PR #16** - Group Interactivity Fix (ready to merge)
+## PR Status:
+1. **PR #18** - Pan Control Restoration (READY TO MERGE) ✅
+   - All features implemented and tested
+   - CHANGELOG.md updated
+   - PR description updated with test results
+   
+2. **PR #16** - Group Interactivity Fix (ready to merge)
    - Simplified interactivity handling
    - Only sets fader, mute, pan as interactive
    - Meters/labels remain non-interactive
    
-2. **PR #15** - Refresh Track Renumbering Fix (ready to merge)
+3. **PR #15** - Refresh Track Renumbering Fix (ready to merge)
    - Registration system for track groups
    - Fixes refresh when tracks renumbered in Ableton
 
-## Next Steps:
-1. User tests optimized pan features in TouchOSC
-2. If issues found, fix and update version
-3. Update CHANGELOG.md after testing success
-4. Merge PR #18 after approval
-5. Consider merging pending PRs #15 and #16
+## Completed in This Session:
+1. ✅ Analyzed old pan control code (v1.4.1)
+2. ✅ Identified missing features (color change & double-tap)
+3. ✅ Implemented features in v1.5.2
+4. ✅ Optimized performance in v1.5.3
+5. ✅ Updated CHANGELOG.md
+6. ✅ Updated PR description
+7. ✅ All testing completed successfully
 
-## Session Notes:
-- User confirmed logger functionality was intentionally removed
-- Optimized for performance by removing continuous update() calls
-- Color changes now event-driven (onValueChanged) instead of polling
-- All features preserved with better performance
+## Next Steps:
+1. Merge PR #18 (pan control restoration)
+2. Consider merging pending PRs #15 and #16
+3. Delete feature branch after merge
+
+## Session Summary:
+Successfully restored missing pan control features that were accidentally removed. The implementation focuses on performance and simplicity, with color changes now being event-driven rather than continuously polled. All functionality has been tested and confirmed working.

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -1,48 +1,63 @@
 # Thread Progress Tracking
 
 ## CRITICAL CURRENT STATE
-**✅ READY FOR MERGE - TESTED & APPROVED:**
-- [x] Currently working on: Fix group interactivity bug - COMPLETE
-- [x] Testing successful - simplified solution works correctly
-- [x] CHANGELOG.md updated
-- [x] All scripts have DEBUG = 0 for production
-- [ ] Waiting for: User to merge PR #16
+**⚠️ WORKING ON PAN CONTROL RESTORATION:**
+- [ ] Currently working on: Restoring missing pan control features
+- [ ] Waiting for: User to test color change and double-tap functionality
+- [ ] Branch: feature/restore-pan-features
+- [ ] PR #18 created
 
-## Current Task: Fix Group Interactivity Bug - COMPLETE
+## Current Task: Restore Missing Pan Control Features
 **Started**: 2025-07-05  
-**Branch**: feature/fix-group-interactivity
-**Status**: PRODUCTION_READY
-**PR**: #16 - Ready to merge
+**Branch**: feature/restore-pan-features
+**Status**: IMPLEMENTED_NOT_TESTED
+**PR**: #18 - Implementation complete, awaiting testing
 
-### Solution Summary:
-Simplified the interactivity handling to only set controls that need to become interactive (fader, mute, pan). Removed unnecessary code that was setting non-interactive states. Let TouchOSC editor handle non-interactive state for meters and labels.
+### Changes Made:
+1. ✅ **pan_control.lua v1.5.1 → v1.5.2**:
+   - Restored color change functionality
+   - Added COLOR_CENTERED and COLOR_OFF_CENTER constants
+   - Restored update() function for visual feedback
+   - Restored double-tap detection logic
+   - Added DOUBLE_TAP_DELAY constant (300ms)
+   - Integrated double-tap handling in onValueChanged()
+   - Set initial color in init()
 
-### Final Changes:
-1. ✅ **group_init.lua v1.16.4**:
-   - Simplified `setGroupEnabled` function
-   - Only handles fader, mute, pan interactivity
-   - Removed unnecessary non-interactive code
-   - **DEBUG = 0** (verified)
+### Features Restored:
+1. **Color Change**: 
+   - Gray (#646464) when pan is centered
+   - Cyan (#34C1DC) when pan is off-center
+   - Uses update() function to continuously check position
 
-### Testing Results:
-- ✅ Meters and labels remain non-interactive when group is mapped
-- ✅ Fader, mute, pan become interactive correctly
-- ✅ Clean, simple solution tested successfully
+2. **Double-tap to Center**:
+   - 300ms time window for double-tap detection
+   - Centers pan to 0.5 (TouchOSC) / 0 (Ableton)
+   - Sends OSC message to update Ableton
 
-### Production Ready Checklist:
-- ✅ All scripts have DEBUG = 0
-- ✅ CHANGELOG.md updated
-- ✅ PR description updated with simplified approach
-- ✅ Testing successful
-- ✅ No DEBUG flags or development artifacts remain
+### Missing Features Analysis:
+Based on comparison with old v1.4.1 code, these were the only missing features. The current version has additional improvements like:
+- Better state management
+- Connection routing support
+- Notify handlers for track changes
+- Touch state tracking to prevent jumps
 
-## Previous Tasks Completed:
-1. **Refresh Track Renumbering Fix** - PR #15 ready to merge (from previous thread)
-2. **Notify Usage Analysis** - Merged PR #12
-3. **Remove Centralized Logging** - Merged PR #11
-4. **Dead Code Removal** - Completed in PR #12
+## Testing Needed:
+- [ ] Verify color changes when moving pan
+- [ ] Test double-tap centers the pan
+- [ ] Confirm no performance issues
+- [ ] Test with regular tracks
+- [ ] Test with return tracks
+- [ ] Verify multi-connection support
+
+## Previous Completed Tasks:
+1. **Group Interactivity Fix** - PR #16 ready to merge
+2. **Refresh Track Renumbering Fix** - PR #15 ready to merge
+3. **Notify Usage Analysis** - Merged PR #12
+4. **Remove Centralized Logging** - Merged PR #11
+5. **Dead Code Removal** - Completed in PR #12
 
 ## Next Steps:
-1. **Merge PR #16** to main branch
-2. Close related issue if any
-3. Check if PR #15 should still be merged
+1. User tests the restored features
+2. Fix any issues found during testing
+3. Update CHANGELOG.md
+4. Merge PR #18 after successful testing

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -2,10 +2,10 @@
 
 ## CRITICAL CURRENT STATE
 **⚠️ WORKING ON PAN CONTROL RESTORATION:**
-- [ ] Currently working on: Restoring missing pan control features
-- [ ] Waiting for: User to test color change and double-tap functionality
+- [x] Currently working on: Restored missing pan control features (color change & double-tap)
+- [ ] Waiting for: User to test implementation in TouchOSC
 - [ ] Branch: feature/restore-pan-features
-- [ ] PR #18 created
+- [ ] PR #18 created and ready for testing
 
 ## Current Task: Restore Missing Pan Control Features
 **Started**: 2025-07-05  
@@ -22,42 +22,62 @@
    - Added DOUBLE_TAP_DELAY constant (300ms)
    - Integrated double-tap handling in onValueChanged()
    - Set initial color in init()
+   - **DEBUG = 0** (production ready)
 
 ### Features Restored:
 1. **Color Change**: 
    - Gray (#646464) when pan is centered
    - Cyan (#34C1DC) when pan is off-center
    - Uses update() function to continuously check position
+   - 0.01 threshold to avoid flickering
 
 2. **Double-tap to Center**:
    - 300ms time window for double-tap detection
    - Centers pan to 0.5 (TouchOSC) / 0 (Ableton)
    - Sends OSC message to update Ableton
+   - Logs double-tap detection (when DEBUG=1)
 
-### Missing Features Analysis:
-Based on comparison with old v1.4.1 code, these were the only missing features. The current version has additional improvements like:
-- Better state management
-- Connection routing support
-- Notify handlers for track changes
-- Touch state tracking to prevent jumps
+### Implementation Analysis:
+- Compared with old v1.4.1 code provided by user
+- Identified exactly 2 missing features (color change & double-tap)
+- Current version has additional improvements:
+  - Better state management (isTouching flag)
+  - Connection routing support
+  - Notify handlers for track changes
+  - Touch state tracking to prevent value jumps
+- Other scripts checked - no missing features found
 
-## Testing Needed:
-- [ ] Verify color changes when moving pan
-- [ ] Test double-tap centers the pan
-- [ ] Confirm no performance issues
+### Testing Checklist:
+- [ ] Verify pan color is gray when centered
+- [ ] Verify pan color is cyan when off-center
+- [ ] Test double-tap centers the pan to 0.5
+- [ ] Confirm OSC message sent to Ableton on double-tap
 - [ ] Test with regular tracks
 - [ ] Test with return tracks
-- [ ] Verify multi-connection support
+- [ ] Verify multi-connection support works
+- [ ] Check no performance issues with update() function
+- [ ] Confirm version 1.5.2 loads in logs
 
-## Previous Completed Tasks:
-1. **Group Interactivity Fix** - PR #16 ready to merge
-2. **Refresh Track Renumbering Fix** - PR #15 ready to merge
-3. **Notify Usage Analysis** - Merged PR #12
-4. **Remove Centralized Logging** - Merged PR #11
-5. **Dead Code Removal** - Completed in PR #12
+## Previous PRs Pending:
+1. **PR #16** - Group Interactivity Fix (ready to merge)
+   - Simplified interactivity handling
+   - Only sets fader, mute, pan as interactive
+   - Meters/labels remain non-interactive
+   
+2. **PR #15** - Refresh Track Renumbering Fix (ready to merge)
+   - Registration system for track groups
+   - Fixes refresh when tracks renumbered in Ableton
 
 ## Next Steps:
-1. User tests the restored features
-2. Fix any issues found during testing
-3. Update CHANGELOG.md
-4. Merge PR #18 after successful testing
+1. User tests restored pan features in TouchOSC
+2. If issues found, fix and update version
+3. Update CHANGELOG.md after testing success
+4. Merge PR #18 after approval
+5. Consider merging pending PRs #15 and #16
+
+## Session Notes:
+- User reported pan control lost color change and double-tap functionality
+- Old working version (v1.4.1) was provided as reference
+- Implementation kept simple and performant
+- All project rules followed (local logging, Color constructor, etc.)
+- No other scripts were missing features


### PR DESCRIPTION
## Description
Restoring two critical features that were accidentally removed from the pan control script:
1. **Visual feedback**: Color change when pan is centered vs off-center
2. **Double-tap to center**: Quick gesture to reset pan to center position

## Features Restored
- Color change: Gray (#646464) when centered, cyan (#34C1DC) when off-center
- Double-tap detection with 300ms threshold to center pan

## Implementation Details
- Version 1.5.3 - Optimized performance by removing continuous update() calls
- Color changes are now event-driven in onValueChanged()
- Preserved all existing functionality while improving efficiency
- Maintains compatibility with current architecture

## Testing Status ✅
All features have been tested and confirmed working:
- ✅ Color changes correctly when pan moves from center
- ✅ Double-tap centers the pan
- ✅ No performance issues introduced
- ✅ Works with regular tracks
- ✅ Works with return tracks
- ✅ Multi-connection support maintained

**Ready to merge!**