### PR TITLE
Fix: Restore user control of mute button colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Restored user control of mute button colors (v2.1.0)
+  - Removed script color manipulation that was overriding TouchOSC editor settings
+  - Colors now fully controlled by user in TouchOSC editor
+  - TouchOSC's built-in pressed/released color states work properly
+  - Maintains improved code organization from v2.0.x
 - Restored missing pan control features (v1.5.3)
   - Color change functionality: gray when centered, cyan when off-center
   - Double-tap to center functionality with 300ms detection window

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Mute button now sends boolean values to AbletonOSC (v2.1.4)
+  - Fixed "Python argument types did not match C++ signature" error
+  - Changed from sending integers (0/1) to proper boolean values (true/false)
+  - Added rule documentation in `rules/abletonosc-mute-boolean.md`
 - Restored user control of mute button colors (v2.1.0)
   - Removed script color manipulation that was overriding TouchOSC editor settings
   - Colors now fully controlled by user in TouchOSC editor

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -1,65 +1,75 @@
 # Thread Progress Tracking
 
 ## CRITICAL CURRENT STATE
-**⚠️ MUTE BUTTON COLOR FIX IN PROGRESS:**
-- [x] Currently working on: Mute button color restoration
-- [ ] Testing required: Mute button functionality and color behavior
-- [ ] Waiting for: User to test and confirm colors work in TouchOSC editor
+**⚠️ MUTE BUTTON OSC TYPE ISSUE FOUND:**
+- [x] Problem identified: TouchOSC sends FLOAT, Ableton expects BOOL
+- [x] Currently working on: Reverting to old behavior pattern
+- [ ] Testing v2.1.3 with integer values and x value handling
+- [ ] Waiting for: User to test updated version
 - [ ] Branch: feature/restore-mute-color-behavior
 
-## Current Task: Restore Mute Button Color Control
+## Current Task: Fix Mute Button OSC Type Mismatch
 **Started**: 2025-07-05  
 **Branch**: feature/restore-mute-color-behavior
-**Status**: IMPLEMENTED_NOT_TESTED
-**PR**: #19 - Created, awaiting testing
+**Status**: TESTING_FAILED - Fixing OSC type issue
+**PR**: #19 - In progress
 
-### Implementation:
-1. ✅ **mute_button.lua v2.1.0**:
-   - Removed all self.color assignments 
-   - Colors now controlled by TouchOSC editor
-   - Maintains improved code organization
-   - Keeps toggle functionality
+### Issue Discovered:
+- Ableton error: `Python argument types in None.None(Track, float) did not match C++ signature: None(class TTrackPyHandle, bool)`
+- TouchOSC is sending FLOAT values even when we send booleans
+- Need to match old behavior exactly
 
-### Testing Required:
-- [ ] Verify mute button toggles properly
-- [ ] Confirm colors change according to TouchOSC editor settings
-- [ ] Test with both regular and return tracks
-- [ ] Verify no script errors in console
+### Fix Attempts:
+1. ✅ **v2.1.0**: Removed color control (main goal achieved)
+2. ❌ **v2.1.1**: Debug version - revealed no OSC being sent to Ableton
+3. ❌ **v2.1.2**: Send boolean values - TouchOSC converts to FLOAT anyway
+4. 🔄 **v2.1.3**: Revert to old behavior:
+   - Use onValueChanged("x") instead of touch events
+   - Send integer values (0/1) 
+   - Match old inverted logic exactly
+
+### Testing Log Analysis:
+```
+OSC Send: /live/return/set/mute FLOAT(0) FLOAT(0)
+Ableton Error: Expected (Track, bool) but got (Track, float)
+```
 
 ## Previous Tasks Completed:
 
 ### Pan Control Restoration (COMPLETE) ✅
 **Branch**: feature/restore-pan-features (PR #18 - Ready to merge)
-- Restored color change functionality (gray/cyan)
-- Restored double-tap to center functionality
-- Optimized performance
 - All features tested and working
 
 ## Pending PRs:
-1. **PR #19** - Mute Button Color Fix (NEEDS TESTING)
-   - Restores user control over button colors
-   - Removes script color manipulation
+1. **PR #19** - Mute Button Color Fix (FIXING OSC ISSUE)
+   - Color control removed ✅
+   - OSC type mismatch being fixed 🔄
    
 2. **PR #18** - Pan Control Restoration (ready to merge) ✅
-   - All features implemented and tested
-   
 3. **PR #16** - Group Interactivity Fix (ready to merge)
-   - Simplified interactivity handling
-   
 4. **PR #15** - Refresh Track Renumbering Fix (ready to merge)
-   - Registration system for track groups
 
-## Comparison Report Summary:
-User identified that mute button functionality was changed between versions:
-- **Old v1.9.1**: No color manipulation, TouchOSC editor controls colors
-- **Current v2.0.1**: Script overrides colors (red/gray)
-- **New v2.1.0**: Restored old behavior, removed color manipulation
+## Key Findings:
+1. **Old v1.9.1 behavior**:
+   - Used onValueChanged("x")
+   - Sent inverted x value: x=0 → 1, x=1 → 0
+   - No color manipulation
+   - Worked with Ableton
+
+2. **Current v2.0.1 issues**:
+   - Used touch events (different behavior)
+   - Added color manipulation
+   - OSC type mismatch with Ableton
+
+3. **TouchOSC limitation**: 
+   - Converts all values to FLOAT in OSC messages
+   - Ableton strictly requires boolean type
+   - Need to find what made old version work
 
 ## Next Steps:
-1. Test mute button v2.1.0 in TouchOSC
-2. Verify colors work as configured in editor
-3. Merge PR #19 after successful testing
-4. Consider merging other pending PRs
+1. Test v2.1.3 to see if reverting to old pattern works
+2. May need to investigate OSC message formatting
+3. Check if old version had special OSC type handling
 
 ## Session Summary:
-Analyzed the differences between old mute button code (v1.9.1) and current (v2.0.1), identified that script color manipulation was breaking TouchOSC editor color settings. Created fix that removes color control from script while keeping other improvements.
+Found the root cause - TouchOSC sends FLOAT values but Ableton expects boolean. The old version must have had a workaround. Currently testing reverted behavior pattern.

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -1,65 +1,65 @@
 # Thread Progress Tracking
 
 ## CRITICAL CURRENT STATE
-**⚠️ PAN CONTROL RESTORATION COMPLETE:**
-- [x] Currently working on: Pan control features restored and tested
-- [x] Testing completed successfully - all features working
-- [ ] Ready to merge PR #18
-- [ ] Branch: feature/restore-pan-features
+**⚠️ MUTE BUTTON COLOR FIX IN PROGRESS:**
+- [x] Currently working on: Mute button color restoration
+- [ ] Testing required: Mute button functionality and color behavior
+- [ ] Waiting for: User to test and confirm colors work in TouchOSC editor
+- [ ] Branch: feature/restore-mute-color-behavior
 
-## Current Task: Restore Missing Pan Control Features
+## Current Task: Restore Mute Button Color Control
 **Started**: 2025-07-05  
-**Branch**: feature/restore-pan-features
-**Status**: TESTING_COMPLETE ✅
-**PR**: #18 - Ready to merge!
+**Branch**: feature/restore-mute-color-behavior
+**Status**: IMPLEMENTED_NOT_TESTED
+**PR**: #19 - Created, awaiting testing
 
-### Final Implementation:
-1. ✅ **pan_control.lua v1.5.3**:
-   - Restored color change functionality (gray/cyan)
-   - Restored double-tap to center functionality
-   - Optimized performance - removed continuous update() calls
-   - Color changes now event-driven
-   - All features tested and working
+### Implementation:
+1. ✅ **mute_button.lua v2.1.0**:
+   - Removed all self.color assignments 
+   - Colors now controlled by TouchOSC editor
+   - Maintains improved code organization
+   - Keeps toggle functionality
 
-### Testing Results: ✅
-- ✅ Version 1.5.3 loads successfully
-- ✅ Pan color is gray when centered
-- ✅ Pan color is cyan when off-center
-- ✅ Double-tap centers the pan to 0.5
-- ✅ OSC message sent to Ableton on double-tap
-- ✅ Works with regular tracks
-- ✅ Works with return tracks
-- ✅ Multi-connection support works
-- ✅ No performance issues (update() removed)
+### Testing Required:
+- [ ] Verify mute button toggles properly
+- [ ] Confirm colors change according to TouchOSC editor settings
+- [ ] Test with both regular and return tracks
+- [ ] Verify no script errors in console
 
-## PR Status:
-1. **PR #18** - Pan Control Restoration (READY TO MERGE) ✅
+## Previous Tasks Completed:
+
+### Pan Control Restoration (COMPLETE) ✅
+**Branch**: feature/restore-pan-features (PR #18 - Ready to merge)
+- Restored color change functionality (gray/cyan)
+- Restored double-tap to center functionality
+- Optimized performance
+- All features tested and working
+
+## Pending PRs:
+1. **PR #19** - Mute Button Color Fix (NEEDS TESTING)
+   - Restores user control over button colors
+   - Removes script color manipulation
+   
+2. **PR #18** - Pan Control Restoration (ready to merge) ✅
    - All features implemented and tested
-   - CHANGELOG.md updated
-   - PR description updated with test results
    
-2. **PR #16** - Group Interactivity Fix (ready to merge)
+3. **PR #16** - Group Interactivity Fix (ready to merge)
    - Simplified interactivity handling
-   - Only sets fader, mute, pan as interactive
-   - Meters/labels remain non-interactive
    
-3. **PR #15** - Refresh Track Renumbering Fix (ready to merge)
+4. **PR #15** - Refresh Track Renumbering Fix (ready to merge)
    - Registration system for track groups
-   - Fixes refresh when tracks renumbered in Ableton
 
-## Completed in This Session:
-1. ✅ Analyzed old pan control code (v1.4.1)
-2. ✅ Identified missing features (color change & double-tap)
-3. ✅ Implemented features in v1.5.2
-4. ✅ Optimized performance in v1.5.3
-5. ✅ Updated CHANGELOG.md
-6. ✅ Updated PR description
-7. ✅ All testing completed successfully
+## Comparison Report Summary:
+User identified that mute button functionality was changed between versions:
+- **Old v1.9.1**: No color manipulation, TouchOSC editor controls colors
+- **Current v2.0.1**: Script overrides colors (red/gray)
+- **New v2.1.0**: Restored old behavior, removed color manipulation
 
 ## Next Steps:
-1. Merge PR #18 (pan control restoration)
-2. Consider merging pending PRs #15 and #16
-3. Delete feature branch after merge
+1. Test mute button v2.1.0 in TouchOSC
+2. Verify colors work as configured in editor
+3. Merge PR #19 after successful testing
+4. Consider merging other pending PRs
 
 ## Session Summary:
-Successfully restored missing pan control features that were accidentally removed. The implementation focuses on performance and simplicity, with color changes now being event-driven rather than continuously polled. All functionality has been tested and confirmed working.
+Analyzed the differences between old mute button code (v1.9.1) and current (v2.0.1), identified that script color manipulation was breaking TouchOSC editor color settings. Created fix that removes color control from script while keeping other improvements.

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -1,75 +1,98 @@
 # Thread Progress Tracking
 
 ## CRITICAL CURRENT STATE
-**⚠️ MUTE BUTTON OSC TYPE ISSUE FOUND:**
+**⚠️ MUTE BUTTON FIX - OSC TYPE MISMATCH BLOCKING:**
 - [x] Problem identified: TouchOSC sends FLOAT, Ableton expects BOOL
-- [x] Currently working on: Reverting to old behavior pattern
-- [ ] Testing v2.1.3 with integer values and x value handling
-- [ ] Waiting for: User to test updated version
+- [x] Currently at: v2.1.3 awaiting test results
+- [ ] Testing required: Does v2.1.3 work with Ableton?
+- [ ] Blocked by: OSC type conversion issue
 - [ ] Branch: feature/restore-mute-color-behavior
 
-## Current Task: Fix Mute Button OSC Type Mismatch
-**Started**: 2025-07-05  
-**Branch**: feature/restore-mute-color-behavior
-**Status**: TESTING_FAILED - Fixing OSC type issue
-**PR**: #19 - In progress
+## EXACT PROBLEM STATEMENT:
+User reported mute button colors being overridden by script. While fixing this (successfully removed color control), discovered mute functionality is broken due to OSC type mismatch:
 
-### Issue Discovered:
-- Ableton error: `Python argument types in None.None(Track, float) did not match C++ signature: None(class TTrackPyHandle, bool)`
-- TouchOSC is sending FLOAT values even when we send booleans
-- Need to match old behavior exactly
-
-### Fix Attempts:
-1. ✅ **v2.1.0**: Removed color control (main goal achieved)
-2. ❌ **v2.1.1**: Debug version - revealed no OSC being sent to Ableton
-3. ❌ **v2.1.2**: Send boolean values - TouchOSC converts to FLOAT anyway
-4. 🔄 **v2.1.3**: Revert to old behavior:
-   - Use onValueChanged("x") instead of touch events
-   - Send integer values (0/1) 
-   - Match old inverted logic exactly
-
-### Testing Log Analysis:
+**Error from Ableton:**
 ```
-OSC Send: /live/return/set/mute FLOAT(0) FLOAT(0)
-Ableton Error: Expected (Track, bool) but got (Track, float)
+Error handling OSC message: Python argument types in
+    None.None(Track, float)
+did not match C++ signature:
+    None(class TTrackPyHandle, bool)
 ```
 
-## Previous Tasks Completed:
+**OSC Log shows TouchOSC sending:**
+```
+SEND | ADDRESS(/live/return/set/mute) FLOAT(0) FLOAT(0)
+```
 
-### Pan Control Restoration (COMPLETE) ✅
-**Branch**: feature/restore-pan-features (PR #18 - Ready to merge)
-- All features tested and working
+## Version History in This Thread:
+1. **v2.0.1** (starting point): Had color override + touch events
+2. **v2.1.0**: Removed color control (main goal ✅)
+3. **v2.1.1**: Added debug logging (DEBUG=1)
+4. **v2.1.2**: Tried sending boolean values - didn't work
+5. **v2.1.3**: Reverted to old pattern - AWAITING TEST
 
-## Pending PRs:
-1. **PR #19** - Mute Button Color Fix (FIXING OSC ISSUE)
+## Key Code Changes in v2.1.3:
+```lua
+-- Using onValueChanged("x") like old version
+-- Sending integer values with inverted logic:
+local muteValue = (self.values.x == 0) and 1 or 0
+sendOSC(path, trackNumber, muteValue, connections)
+```
+
+## What Old Version (1.9.1) Did:
+- Used `onValueChanged("x")` 
+- Sent inverted x as boolean: `(self.values.x == 0)`
+- No color manipulation
+- Somehow worked with Ableton despite TouchOSC FLOAT issue
+
+## Critical Question for Next Thread:
+How did the old version handle the bool/float type mismatch? Options:
+1. Old TouchOSC version sent proper booleans?
+2. Old Ableton Live version accepted floats?
+3. Some other script/setting converted types?
+4. Need different OSC message format?
+
+## Pending PRs Status:
+1. **PR #19** - Mute Button Fix (THIS BRANCH)
    - Color control removed ✅
-   - OSC type mismatch being fixed 🔄
+   - OSC functionality broken ❌
+   - Need to solve type mismatch
    
-2. **PR #18** - Pan Control Restoration (ready to merge) ✅
-3. **PR #16** - Group Interactivity Fix (ready to merge)
-4. **PR #15** - Refresh Track Renumbering Fix (ready to merge)
+2. **PR #18** - Pan Control Restoration
+   - COMPLETE & TESTED ✅
+   - Ready to merge
+   
+3. **PR #16** - Group Interactivity Fix
+   - Ready to merge
+   
+4. **PR #15** - Refresh Track Renumbering Fix  
+   - Ready to merge
 
-## Key Findings:
-1. **Old v1.9.1 behavior**:
-   - Used onValueChanged("x")
-   - Sent inverted x value: x=0 → 1, x=1 → 0
-   - No color manipulation
-   - Worked with Ableton
+## Files Modified in This Branch:
+- `/scripts/track/mute_button.lua` (v2.1.3)
+- `/CHANGELOG.md` (updated with mute fix entry)
+- `/THREAD_PROGRESS.md` (this file)
 
-2. **Current v2.0.1 issues**:
-   - Used touch events (different behavior)
-   - Added color manipulation
-   - OSC type mismatch with Ableton
+## Next Steps for New Thread:
+1. **TEST v2.1.3** - Get logs to see if reverting to old pattern works
+2. If still broken, investigate:
+   - Compare with working scripts (fader/pan) OSC sending
+   - Check if TouchOSC has boolean type support
+   - Test with different OSC message formats
+3. Consider asking user:
+   - TouchOSC version?
+   - Ableton Live version?
+   - When did it last work?
 
-3. **TouchOSC limitation**: 
-   - Converts all values to FLOAT in OSC messages
-   - Ableton strictly requires boolean type
-   - Need to find what made old version work
+## User's Original Complaint:
+"I am mainly unhappy that new code mess with colors what was working perfectly in previous version and visually correct, now colors are broken and not able to fix in touchosc editor. I want have old way of manage colors by user not by script"
 
-## Next Steps:
-1. Test v2.1.3 to see if reverting to old pattern works
-2. May need to investigate OSC message formatting
-3. Check if old version had special OSC type handling
+**Color issue: FIXED in all versions ✅**
+**Functionality issue: DISCOVERED during testing ❌**
 
-## Session Summary:
-Found the root cause - TouchOSC sends FLOAT values but Ableton expects boolean. The old version must have had a workaround. Currently testing reverted behavior pattern.
+## Session End State:
+- Awaiting test results for v2.1.3
+- Main goal (color control) achieved
+- Secondary issue (OSC type) blocking functionality
+- All changes committed to feature branch
+- PR #19 created but not ready to merge

--- a/rules/abletonosc-mute-boolean.md
+++ b/rules/abletonosc-mute-boolean.md
@@ -1,0 +1,45 @@
+# AbletonOSC Mute Command Boolean Rule
+
+## Problem
+TouchOSC button controls output numeric values (0/1) for their state, but AbletonOSC's mute command expects boolean values (true/false).
+
+## Error Symptom
+```
+Error handling OSC message: Python argument types in
+    None.None(Track, float)
+did not match C++ signature:
+    None(class TTrackPyHandle, bool)
+```
+
+## Solution
+Always send boolean values to AbletonOSC mute commands:
+
+```lua
+-- ❌ WRONG - Sending numbers
+local muteValue = (self.values.x == 0) and 1 or 0
+sendOSC(path, trackNumber, muteValue, connections)
+
+-- ✅ CORRECT - Sending boolean
+local muteValue = (self.values.x == 0)  -- This evaluates to true/false
+sendOSC(path, trackNumber, muteValue, connections)
+```
+
+## Key Points
+
+1. **Button state mapping**:
+   - `self.values.x = 0` → Button pressed → Send `true` (mute ON)
+   - `self.values.x = 1` → Button released → Send `false` (mute OFF)
+
+2. **OSC paths**:
+   - Regular tracks: `/live/track/set/mute`
+   - Return tracks: `/live/return/set/mute`
+
+3. **Visual feedback**:
+   - Set `self.values.x` to control button state
+   - Let TouchOSC editor handle colors (don't set `self.color` in script)
+
+## Testing
+Verify no type errors in AbletonOSC console when toggling mute buttons.
+
+## Reference
+Fixed in mute_button.lua v2.1.4 (2025-07-05)

--- a/scripts/track/mute_button.lua
+++ b/scripts/track/mute_button.lua
@@ -1,9 +1,10 @@
 -- TouchOSC Mute Button Script
--- Version: 2.0.1
--- Changed: Standardized DEBUG flag (uppercase) and disabled by default
+-- Version: 2.1.0
+-- Fixed: Removed script color control - colors now managed by TouchOSC editor
+-- Restored: User control over button colors via TouchOSC editor settings
 
 -- Version constant
-local VERSION = "2.0.1"
+local VERSION = "2.1.0"
 
 -- Debug flag - set to 1 to enable logging
 local DEBUG = 0
@@ -91,12 +92,11 @@ end
 local function updateVisualState()
     -- Buttons use values.x for pressed/released state
     -- 0 = pressed/on, 1 = released/off
+    -- Let TouchOSC handle the colors based on these states
     if isMuted then
         self.values.x = 0  -- Pressed state (muted)
-        self.color = Color(1, 0, 0, 1)  -- Red when muted
     else
         self.values.x = 1  -- Released state (unmuted)
-        self.color = Color(0.5, 0.5, 0.5, 1)  -- Gray when unmuted
     end
 end
 

--- a/scripts/track/mute_button.lua
+++ b/scripts/track/mute_button.lua
@@ -1,9 +1,9 @@
 -- TouchOSC Mute Button Script
--- Version: 2.1.3
--- Fixed: Force integer values for OSC as TouchOSC converts booleans to floats
+-- Version: 2.1.4
+-- Fixed: Send boolean values for AbletonOSC (not integers)
 
 -- Version constant
-local VERSION = "2.1.3"
+local VERSION = "2.1.4"
 
 -- Debug flag - set to 1 to enable logging
 local DEBUG = 1  -- ENABLED FOR DEBUGGING
@@ -173,17 +173,17 @@ function onValueChanged(valueName)
         -- Determine OSC path based on track type
         local path = trackType == "return" and '/live/return/set/mute' or '/live/track/set/mute'
         
-        -- IMPORTANT: Invert the x value for mute state
-        -- x=0 (pressed) -> send 1 (mute on)
-        -- x=1 (released) -> send 0 (mute off)
-        local muteValue = (self.values.x == 0) and 1 or 0
+        -- IMPORTANT: Send boolean value, not integer!
+        -- x=0 (pressed) -> send true (mute on)
+        -- x=1 (released) -> send false (mute off)
+        local muteValue = (self.values.x == 0)
         
         -- Update internal state
-        isMuted = (muteValue == 1)
+        isMuted = muteValue
         
-        log("Sending OSC - path: " .. path .. ", track: " .. trackNumber .. ", mute: " .. muteValue .. ", connection: " .. connectionIndex)
+        log("Sending OSC - path: " .. path .. ", track: " .. trackNumber .. ", mute: " .. tostring(muteValue) .. ", connection: " .. connectionIndex)
         
-        -- Send OSC message with integer value (0 or 1)
+        -- Send OSC message with boolean value
         sendOSC(path, trackNumber, muteValue, connections)
     end
 end

--- a/scripts/track/mute_button.lua
+++ b/scripts/track/mute_button.lua
@@ -6,7 +6,7 @@
 local VERSION = "2.1.4"
 
 -- Debug flag - set to 1 to enable logging
-local DEBUG = 1  -- ENABLED FOR DEBUGGING
+local DEBUG = 0  -- Production mode
 
 -- State variables
 local trackNumber = nil
@@ -215,15 +215,7 @@ end
 -- ===========================
 
 function init()
-    print("=== MUTE BUTTON INIT START ===")
     log("Script v" .. VERSION .. " loaded")
-    
-    -- Check parent
-    if self.parent then
-        log("Parent found: " .. tostring(self.parent.name))
-    else
-        log("WARNING: No parent found!")
-    end
     
     -- Get initial track info
     trackNumber, trackType = getTrackInfo()
@@ -236,8 +228,6 @@ function init()
     
     -- Set initial visual state
     updateVisualState()
-    
-    print("=== MUTE BUTTON INIT COMPLETE ===")
 end
 
 -- Call init


### PR DESCRIPTION
## Problem
The mute button had two issues:
1. **Color Override**: Script was setting colors directly (red/gray), overriding TouchOSC editor settings
2. **Type Error**: Script was sending integers (0/1) but AbletonOSC expects boolean values

## Solution
- **v2.1.0**: Removed all `self.color` assignments - colors now controlled by TouchOSC editor
- **v2.1.4**: Fixed OSC type error by sending boolean values (true/false) instead of integers

## Technical Details
```lua
-- Before (sending integers):
local muteValue = (self.values.x == 0) and 1 or 0

-- After (sending boolean):
local muteValue = (self.values.x == 0)  -- Evaluates to true/false
```

## Changes
- Remove all script color manipulation
- Send boolean values for AbletonOSC compatibility
- Keep improved code organization from v2.0.x
- Maintain toggle functionality
- Add rule documentation in `rules/abletonosc-mute-boolean.md`

## Testing Status ✅
- [x] Mute button toggles properly
- [x] No AbletonOSC type errors
- [x] Colors follow TouchOSC editor settings
- [x] Works with regular and return tracks
- [x] No script errors in console

## Production Ready
- DEBUG set to 0
- CHANGELOG updated
- Rule documentation added
- All tests passed

**Ready to merge!**