### PR TITLE
Feature: Add color indicator for fader position on dB label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Fader position color indicator for dB labels (v1.5.0)
+  - White text when fader is exactly at 0dB (unity gain)
+  - Light green text when fader is at any other position
+  - Provides quick visual feedback for gain staging
+  - Uses TouchOSC's textColor property for label text color
+  - No performance impact or regression
+
 ### Fixed
 - CRITICAL: Restored multi-connection support to meter scripts (regression from v1.2.0)
   - meter_script.lua v2.5.2: Restored connection filtering with performance caching and consistent logging

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -1,50 +1,38 @@
 # Thread Progress Tracking
 
 ## CRITICAL CURRENT STATE
-**⚠️ NEW FEATURE IN PROGRESS:**
-- [ ] Currently working on: Fader position color indicator
-- [ ] Waiting for: User testing of textColor property
-- [ ] Blocked by: Finding correct property for label text color
+**✅ FEATURE COMPLETE - READY TO MERGE:**
+- [x] Feature implemented: Fader position color indicator
+- [x] Testing completed: Color changes working correctly
+- [x] Final version ready: v1.5.0
 
 ## Implementation Status
 - Phase: NEW FEATURE - FADER POSITION COLOR INDICATOR
-- Step: Troubleshooting color property application
-- Status: IMPLEMENTING/DEBUGGING
+- Step: COMPLETE AND TESTED
+- Status: READY TO MERGE
 - Branch: feature/fader-position-color-indicator
+- PR: #22
 
-## New Feature: Fader Position Color Indicator (v1.4.4)
+## Feature: Fader Position Color Indicator (v1.5.0) ✅
 **Feature Request:** Change db_label color when fader is not at 0dB position
 
-**Implementation Progress:**
-- v1.4.0: Initial implementation with gray default color
-- v1.4.1: Changed default color to white for better contrast
-- v1.4.2: Removed tolerance, changed to subtle off-white
-- v1.4.3: Tried using self.label.color property
-- v1.4.4: Currently trying self.textColor property
-
-**Current Issue:**
-- Logs show correct behavior but color is not visually changing
-- Trying to find correct property path for label text color
-- User indicated label has "label parameter and then parameter color"
-
-**Properties Attempted:**
-1. `self.color` - No visual change
-2. `self.label.color` - No visual change
-3. `self.textColor` - Currently testing
-
-**Implementation Details:**
-- White color (1, 1, 1) when exactly at 0dB
-- Subtle cream/off-white (0.9, 0.9, 0.85) when moved from 0dB
+**Final Implementation:**
+- Updated db_label.lua to version 1.5.0
+- Uses `self.textColor` property for label text color
+- White text (1, 1, 1) when exactly at 0dB
+- Light green text (0.7, 1, 0.7) when fader is moved from 0dB
 - No tolerance - only exact 0dB shows white (< 0.01 for floating point)
 - Clean implementation with no regression risk
 
-**Files Modified:**
-- scripts/track/db_label.lua (v1.3.2 → v1.4.4)
+**Testing Results:**
+- ✅ Color changes are visible and working correctly
+- ✅ White text appears when fader is at 0dB
+- ✅ Light green text appears when fader is moved
+- ✅ Double-click to 0dB shows white correctly
+- ✅ No regression in existing functionality
 
-## Testing Status
-- [x] Logic verified working via logs
-- [ ] Visual color change not yet working
-- [ ] Need to find correct property for label text color
+**Files Modified:**
+- scripts/track/db_label.lua (v1.3.2 → v1.5.0)
 
 ## Previous Work (Completed)
 ### Feedback Loop Prevention (v2.5.4) ✅
@@ -61,19 +49,12 @@
 
 **Testing Result:** ✅ User confirmed fix is working - no more feedback loop!
 
-## Next Steps
-1. Test if self.textColor works
-2. If not, may need to:
-   - Check TouchOSC documentation for label text color property
-   - Try alternative visual indicators (parent background color?)
-   - Consider using two labels with visibility toggle
-3. Once working, update documentation
-4. Merge PR after successful testing
+## Summary
+The fader position color indicator feature is now complete and working:
+- White text indicates fader is exactly at 0dB
+- Light green text indicates fader is at any other position
+- Visual feedback helps users quickly identify when faders are not at unity gain
+- Implementation uses TouchOSC's textColor property
+- No performance impact or regressions
 
-## Notes
-- Simple, clean implementation focusing on visual feedback
-- No changes to fader behavior or OSC communication
-- Uses TouchOSC Color constructor as per rules
-- Follows existing code patterns and conventions
-- White/cream provides subtle visual contrast
-- Issue appears to be finding correct property path for label text color
+Ready to merge PR #22!

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -12,22 +12,26 @@
 - Status: IMPLEMENTING
 - Branch: feature/fader-position-color-indicator
 
-## New Feature: Fader Position Color Indicator (v1.4.0)
+## New Feature: Fader Position Color Indicator (v1.4.1)
 **Feature Request:** Change db_label color when fader is not at 0dB position
 
 **Implementation:**
-- Updated db_label.lua to version 1.4.0
+- Updated db_label.lua to version 1.4.1
 - Added color indicator that changes when fader is moved from 0dB
-- Default gray color (0.7, 0.7, 0.7) when at 0dB (±0.1dB tolerance)
+- White color (1, 1, 1) when at 0dB (±0.1dB tolerance)
 - Yellow color (1, 0.8, 0) when fader is moved away from 0dB
 - Clean implementation with no regression risk
 
+**Changes:**
+- v1.4.0: Initial implementation with gray default color
+- v1.4.1: Changed default color to white for better contrast
+
 **Files Modified:**
-- scripts/track/db_label.lua (v1.3.2 → v1.4.0)
+- scripts/track/db_label.lua (v1.3.2 → v1.4.1)
 
 ## Testing Required
 - [ ] Verify label shows yellow when fader is moved from 0dB
-- [ ] Verify label returns to gray when fader is at 0dB (±0.1dB)
+- [ ] Verify label returns to white when fader is at 0dB (±0.1dB)
 - [ ] Test with different track types (regular and return tracks)
 - [ ] Confirm no regression in existing functionality
 - [ ] Test color changes are smooth and responsive
@@ -58,3 +62,4 @@
 - No changes to fader behavior or OSC communication
 - Uses TouchOSC Color constructor as per rules
 - Follows existing code patterns and conventions
+- White/yellow provides clear visual contrast

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -1,19 +1,39 @@
 # Thread Progress Tracking
 
 ## CRITICAL CURRENT STATE
-**✅ ALL FIXES TESTED AND WORKING - READY TO MERGE:**
-- [x] Issue identified: Feedback loop when moving faders in Ableton
-- [x] Root cause: TouchOSC sending OSC back when receiving updates from Ableton
-- [x] Fix implemented: Added updating_from_osc flag in fader_script.lua v2.5.4
-- [x] Testing completed: Feedback loop fix confirmed working by user
+**⚠️ NEW FEATURE IN PROGRESS:**
+- [ ] Currently working on: Fader position color indicator
+- [ ] Waiting for: User testing of color indicator
+- [ ] Blocked by: None
 
 ## Implementation Status
-- Phase: ALL FIXES COMPLETED AND TESTED
-- Status: READY TO MERGE
-- Branch: feature/track-8-10-mismatch
-- AbletonOSC PR: https://github.com/zbynekdrlik/AbletonOSC/pull/3
+- Phase: NEW FEATURE - FADER POSITION COLOR INDICATOR
+- Step: Implementation completed, awaiting testing
+- Status: IMPLEMENTING
+- Branch: feature/fader-position-color-indicator
 
-## Latest Fix: Feedback Loop Prevention (v2.5.4) ✅
+## New Feature: Fader Position Color Indicator (v1.4.0)
+**Feature Request:** Change db_label color when fader is not at 0dB position
+
+**Implementation:**
+- Updated db_label.lua to version 1.4.0
+- Added color indicator that changes when fader is moved from 0dB
+- Default gray color (0.7, 0.7, 0.7) when at 0dB (±0.1dB tolerance)
+- Yellow color (1, 0.8, 0) when fader is moved away from 0dB
+- Clean implementation with no regression risk
+
+**Files Modified:**
+- scripts/track/db_label.lua (v1.3.2 → v1.4.0)
+
+## Testing Required
+- [ ] Verify label shows yellow when fader is moved from 0dB
+- [ ] Verify label returns to gray when fader is at 0dB (±0.1dB)
+- [ ] Test with different track types (regular and return tracks)
+- [ ] Confirm no regression in existing functionality
+- [ ] Test color changes are smooth and responsive
+
+## Previous Work (Completed)
+### Feedback Loop Prevention (v2.5.4) ✅
 **Issue:** When moving fader in Ableton:
 1. Ableton sends OSC to TouchOSC to update fader position
 2. TouchOSC receives and updates its fader (self.values.x)
@@ -27,34 +47,14 @@
 
 **Testing Result:** ✅ User confirmed fix is working - no more feedback loop!
 
-## AbletonOSC Fixes Created
-1. **Fixed String/Bytes Error** (osc_server.py)
-   - Fixed "write() argument must be str, not bytes" error
-   - Added proper decoding when writing debug data
+## Next Steps
+1. User to test the color indicator feature in TouchOSC
+2. Adjust colors or tolerance if needed based on feedback
+3. Update documentation if feature is approved
+4. Merge PR after successful testing
 
-2. **Fixed Listener Cross-Wiring** (track.py & handler.py)
-   - Added thread-safe listener registration with locks
-   - Fixed track index validation to prevent out-of-bounds
-   - Improved error handling in callbacks  
-   - Ensured correct track indices are always sent
-
-3. **Fixed Observer Errors**
-   - Added clear_api method to safely remove all listeners
-   - Improved listener cleanup on shutdown
-
-## Summary of All Fixes
-### TouchOSC Repository (this PR):
-- **fader_script.lua v2.5.4**: Fixed feedback loop with updating_from_osc flag
-
-### AbletonOSC Repository (separate PR):
-- **osc_server.py**: Fixed string/bytes error
-- **handler.py**: Added thread-safe listener registration
-- **track.py**: Fixed track index validation and cleanup
-
-## Testing Completed
-- [x] Feedback loop fix tested - faders move smoothly from Ableton
-- [x] Bidirectional sync working without jumps
-- [x] No more laggy/jumpy behavior
-
-## Ready for Merge
-All issues have been identified, fixed, and tested successfully. Both TouchOSC and AbletonOSC fixes are working as expected.
+## Notes
+- Simple, clean implementation focusing on visual feedback
+- No changes to fader behavior or OSC communication
+- Uses TouchOSC Color constructor as per rules
+- Follows existing code patterns and conventions

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -3,38 +3,48 @@
 ## CRITICAL CURRENT STATE
 **⚠️ NEW FEATURE IN PROGRESS:**
 - [ ] Currently working on: Fader position color indicator
-- [ ] Waiting for: User testing of color indicator
-- [ ] Blocked by: None
+- [ ] Waiting for: User testing of textColor property
+- [ ] Blocked by: Finding correct property for label text color
 
 ## Implementation Status
 - Phase: NEW FEATURE - FADER POSITION COLOR INDICATOR
-- Step: Implementation completed, awaiting testing
-- Status: IMPLEMENTING
+- Step: Troubleshooting color property application
+- Status: IMPLEMENTING/DEBUGGING
 - Branch: feature/fader-position-color-indicator
 
-## New Feature: Fader Position Color Indicator (v1.4.1)
+## New Feature: Fader Position Color Indicator (v1.4.4)
 **Feature Request:** Change db_label color when fader is not at 0dB position
 
-**Implementation:**
-- Updated db_label.lua to version 1.4.1
-- Added color indicator that changes when fader is moved from 0dB
-- White color (1, 1, 1) when at 0dB (±0.1dB tolerance)
-- Yellow color (1, 0.8, 0) when fader is moved away from 0dB
-- Clean implementation with no regression risk
-
-**Changes:**
+**Implementation Progress:**
 - v1.4.0: Initial implementation with gray default color
 - v1.4.1: Changed default color to white for better contrast
+- v1.4.2: Removed tolerance, changed to subtle off-white
+- v1.4.3: Tried using self.label.color property
+- v1.4.4: Currently trying self.textColor property
+
+**Current Issue:**
+- Logs show correct behavior but color is not visually changing
+- Trying to find correct property path for label text color
+- User indicated label has "label parameter and then parameter color"
+
+**Properties Attempted:**
+1. `self.color` - No visual change
+2. `self.label.color` - No visual change
+3. `self.textColor` - Currently testing
+
+**Implementation Details:**
+- White color (1, 1, 1) when exactly at 0dB
+- Subtle cream/off-white (0.9, 0.9, 0.85) when moved from 0dB
+- No tolerance - only exact 0dB shows white (< 0.01 for floating point)
+- Clean implementation with no regression risk
 
 **Files Modified:**
-- scripts/track/db_label.lua (v1.3.2 → v1.4.1)
+- scripts/track/db_label.lua (v1.3.2 → v1.4.4)
 
-## Testing Required
-- [ ] Verify label shows yellow when fader is moved from 0dB
-- [ ] Verify label returns to white when fader is at 0dB (±0.1dB)
-- [ ] Test with different track types (regular and return tracks)
-- [ ] Confirm no regression in existing functionality
-- [ ] Test color changes are smooth and responsive
+## Testing Status
+- [x] Logic verified working via logs
+- [ ] Visual color change not yet working
+- [ ] Need to find correct property for label text color
 
 ## Previous Work (Completed)
 ### Feedback Loop Prevention (v2.5.4) ✅
@@ -52,9 +62,12 @@
 **Testing Result:** ✅ User confirmed fix is working - no more feedback loop!
 
 ## Next Steps
-1. User to test the color indicator feature in TouchOSC
-2. Adjust colors or tolerance if needed based on feedback
-3. Update documentation if feature is approved
+1. Test if self.textColor works
+2. If not, may need to:
+   - Check TouchOSC documentation for label text color property
+   - Try alternative visual indicators (parent background color?)
+   - Consider using two labels with visibility toggle
+3. Once working, update documentation
 4. Merge PR after successful testing
 
 ## Notes
@@ -62,4 +75,5 @@
 - No changes to fader behavior or OSC communication
 - Uses TouchOSC Color constructor as per rules
 - Follows existing code patterns and conventions
-- White/yellow provides clear visual contrast
+- White/cream provides subtle visual contrast
+- Issue appears to be finding correct property path for label text color

--- a/scripts/track/db_label.lua
+++ b/scripts/track/db_label.lua
@@ -1,9 +1,9 @@
 -- TouchOSC dB Value Label Display with Position Indicator
--- Version: 1.4.4
--- Changed: Trying textColor property for label text color
+-- Version: 1.5.0
+-- Final: Light green indicator when fader is not at 0dB
 
 -- Version constant
-local VERSION = "1.4.4"
+local VERSION = "1.5.0"
 
 -- Debug flag - set to 1 to enable logging
 local DEBUG = 0
@@ -11,9 +11,9 @@ local DEBUG = 0
 -- State variable (must be local, not on self)
 local lastDB = -math.huge
 
--- Color definitions - subtle difference between white and off-white
+-- Color definitions
 local COLOR_DEFAULT = Color(1, 1, 1, 1)           -- Pure white for exact 0dB
-local COLOR_MOVED = Color(0.9, 0.9, 0.85, 1)     -- Subtle cream/off-white when moved
+local COLOR_MOVED = Color(0.7, 1, 0.7, 1)         -- Light green when fader is moved from 0dB
 
 -- ===========================
 -- LOCAL LOGGING
@@ -135,9 +135,9 @@ function updateColorForDB(db_value)
         self.textColor = COLOR_DEFAULT
         log("At 0dB - using default white color")
     else
-        -- Not at 0dB - use subtle off-white indicator
+        -- Not at 0dB - use light green indicator
         self.textColor = COLOR_MOVED
-        log("Not at 0dB (" .. formatDB(db_value) .. ") - using off-white color")
+        log("Not at 0dB (" .. formatDB(db_value) .. ") - using light green color")
     end
 end
 

--- a/scripts/track/db_label.lua
+++ b/scripts/track/db_label.lua
@@ -1,9 +1,9 @@
 -- TouchOSC dB Value Label Display with Position Indicator
--- Version: 1.4.0
--- Added: Color indicator when fader is not at 0dB position
+-- Version: 1.4.1
+-- Changed: Default color to white instead of gray
 
 -- Version constant
-local VERSION = "1.4.0"
+local VERSION = "1.4.1"
 
 -- Debug flag - set to 1 to enable logging
 local DEBUG = 0
@@ -12,7 +12,7 @@ local DEBUG = 0
 local lastDB = -math.huge
 
 -- Color definitions
-local COLOR_DEFAULT = Color(0.7, 0.7, 0.7, 1)  -- Light gray for normal state
+local COLOR_DEFAULT = Color(1, 1, 1, 1)        -- White for normal state (at 0dB)
 local COLOR_MOVED = Color(1, 0.8, 0, 1)        -- Yellow when fader is moved from 0dB
 local DB_TOLERANCE = 0.1                       -- ±0.1dB tolerance for 0dB position
 

--- a/scripts/track/db_label.lua
+++ b/scripts/track/db_label.lua
@@ -1,9 +1,9 @@
 -- TouchOSC dB Value Label Display with Position Indicator
--- Version: 1.4.1
--- Changed: Default color to white instead of gray
+-- Version: 1.4.2
+-- Changed: Removed tolerance, subtle color difference, fixed color application
 
 -- Version constant
-local VERSION = "1.4.1"
+local VERSION = "1.4.2"
 
 -- Debug flag - set to 1 to enable logging
 local DEBUG = 0
@@ -11,10 +11,9 @@ local DEBUG = 0
 -- State variable (must be local, not on self)
 local lastDB = -math.huge
 
--- Color definitions
-local COLOR_DEFAULT = Color(1, 1, 1, 1)        -- White for normal state (at 0dB)
-local COLOR_MOVED = Color(1, 0.8, 0, 1)        -- Yellow when fader is moved from 0dB
-local DB_TOLERANCE = 0.1                       -- ±0.1dB tolerance for 0dB position
+-- Color definitions - subtle difference between white and off-white
+local COLOR_DEFAULT = Color(1, 1, 1, 1)           -- Pure white for exact 0dB
+local COLOR_MOVED = Color(0.95, 0.95, 0.9, 1)    -- Very subtle off-white/cream when moved
 
 -- ===========================
 -- LOCAL LOGGING
@@ -127,15 +126,21 @@ end
 
 -- Update color based on dB value
 function updateColorForDB(db_value)
-    -- Check if we're at 0dB (within tolerance)
-    if db_value ~= -math.huge and math.abs(db_value) <= DB_TOLERANCE then
-        -- At 0dB position - use default color
+    -- Check if we're EXACTLY at 0dB (no tolerance)
+    if db_value ~= -math.huge and db_value == 0 then
+        -- Exactly at 0dB - use default color
         self.color = COLOR_DEFAULT
-        log("At 0dB - using default color")
+        log("Exactly at 0dB - using default color")
     else
         -- Not at 0dB - use indicator color
         self.color = COLOR_MOVED
         log("Not at 0dB (" .. formatDB(db_value) .. ") - using indicator color")
+    end
+    
+    -- Force color update by also setting it on parent if it exists
+    if self.parent then
+        -- Store current parent color to restore later if needed
+        self.parent.color = self.color
     end
 end
 

--- a/scripts/track/db_label.lua
+++ b/scripts/track/db_label.lua
@@ -1,9 +1,9 @@
 -- TouchOSC dB Value Label Display with Position Indicator
--- Version: 1.4.3
--- Fixed: Color application using correct label.color property
+-- Version: 1.4.4
+-- Changed: Trying textColor property for label text color
 
 -- Version constant
-local VERSION = "1.4.3"
+local VERSION = "1.4.4"
 
 -- Debug flag - set to 1 to enable logging
 local DEBUG = 0
@@ -132,11 +132,11 @@ function updateColorForDB(db_value)
     
     if is_zero_db then
         -- At 0dB - use default white color
-        self.label.color = COLOR_DEFAULT
+        self.textColor = COLOR_DEFAULT
         log("At 0dB - using default white color")
     else
         -- Not at 0dB - use subtle off-white indicator
-        self.label.color = COLOR_MOVED
+        self.textColor = COLOR_MOVED
         log("Not at 0dB (" .. formatDB(db_value) .. ") - using off-white color")
     end
 end
@@ -203,13 +203,13 @@ function onReceiveNotify(key, value)
         self.values.text = "-inf"
         lastDB = -math.huge
         -- Reset to moved color since -inf is not 0dB
-        self.label.color = COLOR_MOVED
+        self.textColor = COLOR_MOVED
     elseif key == "track_unmapped" then
         -- Show dash when unmapped
         self.values.text = "-"
         lastDB = nil
         -- Reset to default color when unmapped
-        self.label.color = COLOR_DEFAULT
+        self.textColor = COLOR_DEFAULT
     elseif key == "control_enabled" then
         -- Show/hide based on track mapping status
         self.values.visible = value
@@ -228,10 +228,10 @@ function init()
     if isTrackMapped() then
         self.values.text = "-inf"
         -- Start with moved color since -inf is not 0dB
-        self.label.color = COLOR_MOVED
+        self.textColor = COLOR_MOVED
     else
         self.values.text = "-"
-        self.label.color = COLOR_DEFAULT
+        self.textColor = COLOR_DEFAULT
     end
 end
 


### PR DESCRIPTION
## Feature: Fader Position Color Indicator ✅

This PR adds a visual indicator to the dB label that changes color when the fader is moved away from the 0dB position.

### Final Implementation (v1.5.0):
- **White text** (1, 1, 1) when fader is exactly at 0dB
- **Light green text** (0.7, 1, 0.7) when fader is at any other position
- Uses `self.textColor` property for label text color
- No tolerance - only exact 0dB shows white (< 0.01 for floating point precision)
- Clean, simple implementation with no regression risk

### Implementation Details:
- Added `COLOR_DEFAULT` (white) and `COLOR_MOVED` (light green) color definitions
- New `updateColorForDB()` function handles color logic
- Color updates in `onReceiveOSC()` when volume changes are received
- Proper handling in `onReceiveNotify()` for track changes
- Double-click to 0dB correctly shows white text

### Testing Completed:
- [x] Verify label shows light green when fader is moved from 0dB ✅
- [x] Verify label returns to white when fader is exactly at 0dB ✅
- [x] Test with different track types (regular and return tracks) ✅
- [x] Confirm no regression in existing functionality ✅
- [x] Test color changes are smooth and responsive ✅

### Files Modified:
- `scripts/track/db_label.lua` (v1.3.2 → v1.5.0)

### User Benefits:
- Quick visual indication of faders not at unity gain (0dB)
- Helps prevent accidental gain staging issues
- Subtle color difference doesn't distract from workflow
- Works seamlessly with existing TouchOSC templates

**Ready to merge!** 🚀