### PR TITLE
Fix duplicate track names calls during refresh

### DIFF
--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -1,7 +1,35 @@
 # Thread Progress Tracking
 
 ## CRITICAL CURRENT STATE
-**✅ PR #24 READY FOR MERGE:**
+**⚠️ PR #26 IN PROGRESS:**
+- [ ] Currently working on: Fix duplicate track names calls during refresh
+- [ ] Waiting for: User testing of centralized track names retrieval
+- [ ] Blocked by: None
+
+## ACTIVE WORK: DUPLICATE TRACK NAMES FIX
+### Problem Identified:
+- Each track group independently calls `/live/song/get/track_names`
+- Causes duplicate OSC packets during refresh
+- Creates unnecessary network traffic
+
+### Solution Implemented:
+1. **Centralized Queries**: ✅
+   - Document script queries track names once per connection
+   - Caches results in `trackNamesCache`
+   - Distributes to all groups via notification
+
+2. **Updated Scripts**: ✅
+   - `document_script.lua` v2.10.0 - Centralized querying
+   - `group_init.lua` v1.17.0 - Receives names via notification
+
+3. **Testing Required**: ❌
+   - [ ] Verify only one track names query per connection
+   - [ ] Test all track groups map correctly
+   - [ ] Test with multiple connections
+   - [ ] Test with both regular and return tracks
+
+## COMPLETED WORK: DOUBLE-CLICK MUTE (PR #24)
+### Final Status: READY FOR MERGE
 - [x] Double-click mute protection COMPLETE AND WORKING
 - [x] Documentation cleanup COMPLETE
 - [x] Experimental files removed
@@ -9,67 +37,24 @@
 - [x] CHANGELOG finalized for v1.5.0
 - [x] Ready for merge
 
-## FINAL STATUS: READY FOR PRODUCTION
-### Completed Tasks:
-1. **File Cleanup**: ✅
-   - [x] Removed `mute_label.lua` (experimental, not used)
-   - [x] All scripts have correct version numbers
-   - [x] No debug flags enabled (DEBUG = 0)
+## Testing Status Matrix
+| Component | Implemented | Unit Tested | Integration Tested | Multi-Instance Tested | 
+|-----------|------------|-------------|--------------------|-----------------------|
+| document_script v2.10.0 | ✅ | ❌ | ❌ | ❌ |
+| group_init v1.17.0 | ✅ | ❌ | ❌ | ❌ |
+| mute_button v2.7.0 | ✅ | ✅ | ✅ | ✅ |
+| mute_display_label v1.0.1 | ✅ | ✅ | ✅ | ✅ |
 
-2. **Documentation Updates**: ✅
-   - [x] README updated with complete double-click mute section
-   - [x] Template setup instructions included
-   - [x] Configuration examples added
-   - [x] Both button and label setup documented
-
-3. **Changelog Finalization**: ✅
-   - [x] Moved double-click mute to v1.5.0
-   - [x] All changes documented
-   - [x] Version number and date added
-
-4. **PR Readiness**: ✅
-   - [x] PR description reflects final implementation
-   - [x] All commits meaningful
-   - [x] No conflicts with main branch
-   - [x] Ready for merge
-
-## PRODUCTION-READY COMPONENTS
-### Final Solution Architecture:
-```
-[Button Control] + [Display Label]
-- mute_button.lua (v2.7.0) - Interactive control
-- mute_display_label.lua (v1.0.1) - Visual indicator
-```
-
-### Working Features:
-- ✅ Double-click protection for critical tracks
-- ✅ Visual warning with ⚠MUTE⚠ for protected tracks
-- ✅ Single-click for normal tracks
-- ✅ Solid color feedback on buttons
-- ✅ Configuration via simple text format
-- ✅ Backward compatible
-
-## CONFIGURATION FORMAT (FINAL)
-```yaml
-# Add to configuration text:
-double_click_mute: 'instance_GroupName'
-
-# Examples:
-double_click_mute: 'master_A-ReproM'
-double_click_mute: 'band_Drums'
-double_click_mute: 'dj_Master Bus'
-```
-
-## MERGE CHECKLIST
-- [x] All production scripts at correct versions
-- [x] No debug logging enabled
-- [x] Documentation complete
-- [x] Changelog updated
-- [x] Experimental files removed
-- [x] PR description accurate
-- [x] Ready for production use
+## Last User Action
+- Date/Time: 2025-07-07 12:58
+- Action: Reported duplicate track names calls issue
+- Result: Created PR #26 with centralized solution
+- Next Required: Test the fix and provide logs
 
 ## NEXT STEPS
-1. Merge PR #24
-2. Create v1.5.0 release tag
-3. Update TouchOSC template with new controls
+1. User tests PR #26 branch
+2. Verify OSC log shows single track names query
+3. Confirm all track groups still map correctly
+4. If working, merge PR #26
+5. Then merge PR #24 (double-click mute)
+6. Create v1.5.0 release

--- a/scripts/document_script.lua
+++ b/scripts/document_script.lua
@@ -211,14 +211,6 @@ function completeRefreshSequence()
         end
     end
     
-    -- If no connections configured, query connection 1
-    if next(uniqueConnections) == nil then
-        local connections = {true, false, false, false, false, false, false, false, false, false}
-        sendOSC('/live/song/get/track_names', connections)
-        sendOSC('/live/song/get/return_track_names', connections)
-        log("Queried default connection 1")
-    end
-    
     -- Update status
     if status then
         status.values.text = "Ready"

--- a/scripts/document_script.lua
+++ b/scripts/document_script.lua
@@ -182,11 +182,12 @@ function completeRefreshSequence()
         status.values.text = "Refreshing..."
     end
     
-    -- First, notify all groups to prepare for refresh (sets needsRefresh flag)
+    -- Notify all groups to prepare for refresh
+    -- This sets their needsRefresh flag so they'll process incoming track names
     for name, group in pairs(trackGroups) do
         -- Verify group still exists and is valid
         if group and group.notify then
-            group:notify("prepare_refresh")
+            group:notify("refresh_tracks")
         end
     end
     

--- a/scripts/document_script.lua
+++ b/scripts/document_script.lua
@@ -22,21 +22,15 @@ local configText = nil
 -- Store track group references
 local trackGroups = {}
 
--- Track names cache per connection
-local trackNamesCache = {}  -- [connectionIndex] = {regular = {...}, returns = {...}}
-
 -- Startup tracking
 local startupRefreshTime = nil
 local frameCount = 0
 local STARTUP_DELAY_FRAMES = 60  -- Wait 1 second (60 frames at 60fps)
 
 -- Refresh state tracking
-local refreshState = "idle"  -- idle, clearing, waiting, querying, distributing
+local refreshState = "idle"  -- idle, clearing, waiting, refreshing
 local refreshWaitStart = 0
 local REFRESH_WAIT_TIME = 100  -- 100ms delay between clear and refresh
-local queriedConnections = {}  -- Track which connections we've queried
-local receivedTrackNames = {}  -- Track which connections have responded
-local receivedReturnNames = {}  -- Track which connections have responded for returns
 
 -- === LOCAL LOGGING FUNCTION ===
 local function log(message)
@@ -178,23 +172,25 @@ function startRefreshSequence()
     end
 end
 
--- === QUERY TRACK NAMES FROM ALL CONNECTIONS ===
-function queryTrackNames()
-    log("=== QUERYING TRACK NAMES ===")
+-- === COMPLETE REFRESH AFTER DELAY ===
+function completeRefreshSequence()
+    log("=== COMPLETING REFRESH ===")
     
     -- Update status
     local status = root:findByName("global_status")
     if status then
-        status.values.text = "Querying..."
+        status.values.text = "Refreshing..."
     end
     
-    -- Clear tracking tables
-    queriedConnections = {}
-    receivedTrackNames = {}
-    receivedReturnNames = {}
-    trackNamesCache = {}
+    -- First, notify all groups to prepare for refresh (sets needsRefresh flag)
+    for name, group in pairs(trackGroups) do
+        -- Verify group still exists and is valid
+        if group and group.notify then
+            group:notify("prepare_refresh")
+        end
+    end
     
-    -- Query each unique connection
+    -- Query track names once per connection
     local uniqueConnections = {}
     for instance, connIndex in pairs(config.connections) do
         if not uniqueConnections[connIndex] then
@@ -210,7 +206,6 @@ function queryTrackNames()
             sendOSC('/live/song/get/track_names', connections)
             sendOSC('/live/song/get/return_track_names', connections)
             
-            queriedConnections[connIndex] = true
             log("Queried connection " .. connIndex)
         end
     end
@@ -220,49 +215,8 @@ function queryTrackNames()
         local connections = {true, false, false, false, false, false, false, false, false, false}
         sendOSC('/live/song/get/track_names', connections)
         sendOSC('/live/song/get/return_track_names', connections)
-        queriedConnections[1] = true
         log("Queried default connection 1")
     end
-    
-    -- Set state to wait for responses
-    refreshState = "querying"
-end
-
--- === CHECK IF ALL QUERIES COMPLETE ===
-function checkQueriesComplete()
-    -- Check if we've received both regular and return names for all queried connections
-    for connIndex, _ in pairs(queriedConnections) do
-        if not receivedTrackNames[connIndex] or not receivedReturnNames[connIndex] then
-            return false
-        end
-    end
-    return true
-end
-
--- === DISTRIBUTE TRACK NAMES TO GROUPS ===
-function distributeTrackNames()
-    log("=== DISTRIBUTING TRACK NAMES ===")
-    
-    -- Update status
-    local status = root:findByName("global_status")
-    if status then
-        status.values.text = "Distributing..."
-    end
-    
-    -- Distribute to all groups
-    local groupCount = 0
-    for name, group in pairs(trackGroups) do
-        -- Verify group still exists and is valid
-        if group and group.notify then
-            group:notify("track_names_available", trackNamesCache)
-            groupCount = groupCount + 1
-        else
-            -- Remove invalid reference
-            trackGroups[name] = nil
-        end
-    end
-    
-    log("Distributed to " .. groupCount .. " groups")
     
     -- Update status
     if status then
@@ -271,14 +225,6 @@ function distributeTrackNames()
     
     -- Reset state
     refreshState = "idle"
-end
-
--- === COMPLETE REFRESH AFTER DELAY ===
-function completeRefreshSequence()
-    log("=== COMPLETING REFRESH ===")
-    
-    -- Instead of telling groups to refresh individually, query track names centrally
-    queryTrackNames()
 end
 
 -- === GLOBAL HELPER FUNCTIONS ===
@@ -309,12 +255,6 @@ function update()
             refreshState = "refreshing"
             completeRefreshSequence()
         end
-    elseif refreshState == "querying" then
-        -- Check if all queries are complete
-        if checkQueriesComplete() then
-            refreshState = "distributing"
-            distributeTrackNames()
-        end
     end
     
     -- Count frames since startup
@@ -336,9 +276,6 @@ function init()
     -- Clear track groups table
     trackGroups = {}
     
-    -- Clear caches
-    trackNamesCache = {}
-    
     -- Try to parse configuration
     parseConfiguration()
     
@@ -356,10 +293,9 @@ end
 -- === OSC RECEIVE HANDLER ===
 function onReceiveOSC(message, connections)
     local arguments = message[2]
-    local path = message[1]
     
-    -- Handle track names for caching and unfolding
-    if path == '/live/song/get/track_names' then
+    -- Handle track names for unfolding
+    if message[1] == '/live/song/get/track_names' then
         -- Determine which connection this came from
         local sourceConnection = nil
         for i = 1, #connections do
@@ -367,24 +303,6 @@ function onReceiveOSC(message, connections)
                 sourceConnection = i
                 break
             end
-        end
-        
-        if sourceConnection then
-            -- Cache the track names
-            if not trackNamesCache[sourceConnection] then
-                trackNamesCache[sourceConnection] = {}
-            end
-            
-            trackNamesCache[sourceConnection].regular = {}
-            if arguments then
-                for i = 1, #arguments do
-                    trackNamesCache[sourceConnection].regular[i-1] = arguments[i].value
-                end
-            end
-            
-            -- Mark as received
-            receivedTrackNames[sourceConnection] = true
-            log("Cached regular track names from connection " .. sourceConnection)
         end
         
         -- Find which instance this connection belongs to
@@ -399,22 +317,20 @@ function onReceiveOSC(message, connections)
         -- Count unfolds for this instance
         local unfoldedCount = 0
         
-        if arguments then
-            for i = 1, #arguments do
-                local track_index = i - 1
-                local track_name = arguments[i].value
-                
-                -- Check against configured unfold groups
-                for _, unfold_config in ipairs(config.unfold_groups) do
-                    if track_name == unfold_config.group_name then
-                        -- Check if this unfold should apply to this instance
-                        if unfold_config.instance == "all" or unfold_config.instance == sourceInstance then
-                            -- Only send unfold if we have a known source
-                            if sourceConnection and sourceInstance then
-                                local targetConnections = createConnectionTable(sourceConnection)
-                                sendOSC('/live/track/set/fold_state', track_index, false, targetConnections)
-                                unfoldedCount = unfoldedCount + 1
-                            end
+        for i = 1, #arguments do
+            local track_index = i - 1
+            local track_name = arguments[i].value
+            
+            -- Check against configured unfold groups
+            for _, unfold_config in ipairs(config.unfold_groups) do
+                if track_name == unfold_config.group_name then
+                    -- Check if this unfold should apply to this instance
+                    if unfold_config.instance == "all" or unfold_config.instance == sourceInstance then
+                        -- Only send unfold if we have a known source
+                        if sourceConnection and sourceInstance then
+                            local targetConnections = createConnectionTable(sourceConnection)
+                            sendOSC('/live/track/set/fold_state', track_index, false, targetConnections)
+                            unfoldedCount = unfoldedCount + 1
                         end
                     end
                 end
@@ -424,35 +340,6 @@ function onReceiveOSC(message, connections)
         -- Log summary instead of details
         if unfoldedCount > 0 then
             log("Unfolded " .. unfoldedCount .. " groups on " .. (sourceInstance or "unknown"))
-        end
-    
-    -- Handle return track names for caching
-    elseif path == '/live/song/get/return_track_names' then
-        -- Determine which connection this came from
-        local sourceConnection = nil
-        for i = 1, #connections do
-            if connections[i] then
-                sourceConnection = i
-                break
-            end
-        end
-        
-        if sourceConnection then
-            -- Cache the return track names
-            if not trackNamesCache[sourceConnection] then
-                trackNamesCache[sourceConnection] = {}
-            end
-            
-            trackNamesCache[sourceConnection].returns = {}
-            if arguments then
-                for i = 1, #arguments do
-                    trackNamesCache[sourceConnection].returns[i-1] = arguments[i].value
-                end
-            end
-            
-            -- Mark as received
-            receivedReturnNames[sourceConnection] = true
-            log("Cached return track names from connection " .. sourceConnection)
         end
     end
     

--- a/scripts/track/group_init.lua
+++ b/scripts/track/group_init.lua
@@ -394,9 +394,6 @@ end
 function onReceiveNotify(action)
     if action == "refresh" or action == "refresh_tracks" then
         refreshTrackMapping()
-    elseif action == "prepare_refresh" then
-        -- Just set the flag - document script will send track names
-        needsRefresh = true
     elseif action == "clear_mapping" then
         -- Clear listeners
         clearListeners()

--- a/scripts/track/group_init.lua
+++ b/scripts/track/group_init.lua
@@ -1,9 +1,9 @@
 -- TouchOSC Group Initialization Script with Auto Track Type Detection
--- Version: 1.16.4
--- Changed: Simplified interactivity - only set fader, mute, pan as interactive
+-- Version: 1.17.0
+-- Changed: Receive track names from document script to prevent duplicate queries
 
 -- Version constant
-local SCRIPT_VERSION = "1.16.4"
+local SCRIPT_VERSION = "1.17.0"
 
 -- Debug flag - set to 1 to enable logging
 local DEBUG = 0
@@ -176,6 +176,106 @@ local function notifyChildren(event, value)
     end
 end
 
+-- Process track names received from document script
+local function processTrackNames(trackNamesCache)
+    if not trackNamesCache or not trackNamesCache[connectionIndex] then
+        log("No track names for connection " .. connectionIndex)
+        setGroupEnabled(false)
+        trackNumber = nil
+        trackType = nil
+        needsRefresh = false
+        return
+    end
+    
+    local connectionData = trackNamesCache[connectionIndex]
+    
+    -- Check regular tracks first
+    if connectionData.regular then
+        for trackIndex, trackNameValue in pairs(connectionData.regular) do
+            if trackNameValue == trackName then
+                -- Found our track as a regular track
+                trackNumber = trackIndex
+                trackType = "track"
+                lastVerified = getMillis()
+                trackMapped = true
+                needsRefresh = false
+                
+                log("Mapped to track " .. trackNumber)
+                
+                setGroupEnabled(true)
+                
+                -- Store combined info in tag
+                self.tag = instance .. ":" .. trackNumber .. ":track"
+                
+                -- Notify children
+                notifyChildren("track_changed", trackNumber)
+                notifyChildren("track_type", trackType)
+                
+                -- Build connection table for our specific connection
+                local targetConnections = buildConnectionTable(connectionIndex)
+                
+                -- Start listeners for regular track
+                sendOSC('/live/track/start_listen/volume', trackNumber, targetConnections)
+                sendOSC('/live/track/start_listen/output_meter_level', trackNumber, targetConnections)
+                sendOSC('/live/track/start_listen/mute', trackNumber, targetConnections)
+                sendOSC('/live/track/start_listen/panning', trackNumber, targetConnections)
+                
+                listenersActive = true
+                
+                return
+            end
+        end
+    end
+    
+    -- Check return tracks if not found in regular tracks
+    if connectionData.returns then
+        for returnIndex, returnNameValue in pairs(connectionData.returns) do
+            if returnNameValue == trackName then
+                -- Found our track as a return track
+                trackNumber = returnIndex
+                trackType = "return"
+                lastVerified = getMillis()
+                trackMapped = true
+                needsRefresh = false
+                
+                log("Mapped to return " .. trackNumber)
+                
+                setGroupEnabled(true)
+                
+                -- Store combined info in tag
+                self.tag = instance .. ":" .. trackNumber .. ":return"
+                
+                -- Notify children
+                notifyChildren("track_changed", trackNumber)
+                notifyChildren("track_type", trackType)
+                
+                -- Build connection table for our specific connection
+                local targetConnections = buildConnectionTable(connectionIndex)
+                
+                -- Start listeners for return track
+                sendOSC('/live/return/start_listen/volume', trackNumber, targetConnections)
+                sendOSC('/live/return/start_listen/output_meter_level', trackNumber, targetConnections)
+                sendOSC('/live/return/start_listen/mute', trackNumber, targetConnections)
+                sendOSC('/live/return/start_listen/panning', trackNumber, targetConnections)
+                
+                listenersActive = true
+                
+                return
+            end
+        end
+    end
+    
+    -- Track not found
+    log("Track not found: " .. trackName)
+    setGroupEnabled(false)
+    trackNumber = nil
+    trackType = nil
+    needsRefresh = false
+    
+    -- Notify children
+    notifyChildren("track_unmapped", nil)
+end
+
 function init()
     -- Set tag programmatically
     self.tag = "trackGroup"
@@ -240,12 +340,8 @@ function refreshTrackMapping()
     trackNumber = nil
     trackType = nil
     
-    -- Build connection table for our specific connection
-    local connections = buildConnectionTable(connectionIndex)
-    
-    -- Query both regular tracks and return tracks
-    sendOSC('/live/song/get/track_names', connections)
-    sendOSC('/live/song/get/return_track_names', connections)
+    -- No longer query directly - wait for track names from document script
+    log("Waiting for track names from document script")
 end
 
 function onReceiveOSC(message, connections)
@@ -272,132 +368,18 @@ function onReceiveOSC(message, connections)
         end
     end
     
-    -- Check if this is track names response (regular tracks)
-    if path == '/live/song/get/track_names' then
-        -- Only process if it's from our configured connection
-        if not connections[connectionIndex] then 
-            return true
-        end
-        
-        if needsRefresh then
-            local arguments = message[2]
-            
-            if arguments then
-                for i = 1, #arguments do
-                    if arguments[i] and arguments[i].value then
-                        local trackNameValue = arguments[i].value
-                        
-                        -- EXACT match only for safety
-                        if trackNameValue == trackName then
-                            -- Found our track as a regular track
-                            trackNumber = i - 1
-                            trackType = "track"
-                            lastVerified = getMillis()
-                            trackMapped = true
-                            needsRefresh = false  -- Found it, stop searching
-                            
-                            log("Mapped to track " .. trackNumber)
-                            
-                            setGroupEnabled(true)
-                            
-                            -- Store combined info in tag
-                            self.tag = instance .. ":" .. trackNumber .. ":track"
-                            
-                            -- Notify children
-                            notifyChildren("track_changed", trackNumber)
-                            notifyChildren("track_type", trackType)
-                            
-                            -- Build connection table for our specific connection
-                            local targetConnections = buildConnectionTable(connectionIndex)
-                            
-                            -- Start listeners for regular track
-                            sendOSC('/live/track/start_listen/volume', trackNumber, targetConnections)
-                            sendOSC('/live/track/start_listen/output_meter_level', trackNumber, targetConnections)
-                            sendOSC('/live/track/start_listen/mute', trackNumber, targetConnections)
-                            sendOSC('/live/track/start_listen/panning', trackNumber, targetConnections)
-                            
-                            listenersActive = true
-                            
-                            return true
-                        end
-                    end
-                end
-            end
-        end
-    end
-    
-    -- Check if this is return track names response
-    if path == '/live/song/get/return_track_names' then
-        -- Only process if it's from our configured connection
-        if not connections[connectionIndex] then 
-            return true
-        end
-        
-        if needsRefresh then
-            local arguments = message[2]
-            
-            if arguments then
-                for i = 1, #arguments do
-                    if arguments[i] and arguments[i].value then
-                        local returnNameValue = arguments[i].value
-                        
-                        -- EXACT match only for safety
-                        if returnNameValue == trackName then
-                            -- Found our track as a return track
-                            trackNumber = i - 1
-                            trackType = "return"
-                            lastVerified = getMillis()
-                            trackMapped = true
-                            needsRefresh = false
-                            
-                            log("Mapped to return " .. trackNumber)
-                            
-                            setGroupEnabled(true)
-                            
-                            -- Store combined info in tag
-                            self.tag = instance .. ":" .. trackNumber .. ":return"
-                            
-                            -- Notify children
-                            notifyChildren("track_changed", trackNumber)
-                            notifyChildren("track_type", trackType)
-                            
-                            -- Build connection table for our specific connection
-                            local targetConnections = buildConnectionTable(connectionIndex)
-                            
-                            -- Start listeners for return track
-                            sendOSC('/live/return/start_listen/volume', trackNumber, targetConnections)
-                            sendOSC('/live/return/start_listen/output_meter_level', trackNumber, targetConnections)
-                            sendOSC('/live/return/start_listen/mute', trackNumber, targetConnections)
-                            sendOSC('/live/return/start_listen/panning', trackNumber, targetConnections)
-                            
-                            listenersActive = true
-                            
-                            return true
-                        end
-                    end
-                end
-            end
-            
-            -- If we've checked both regular and return tracks and didn't find it
-            if needsRefresh then
-                log("Track not found: " .. trackName)
-                setGroupEnabled(false)
-                trackNumber = nil
-                trackType = nil
-                needsRefresh = false
-                
-                -- Notify children
-                notifyChildren("track_unmapped", nil)
-            end
-        end
-    end
-    
+    -- No longer handle track names here - they come via notification
     return false
 end
 
-function onReceiveNotify(action)
+function onReceiveNotify(action, value)
     if action == "refresh" or action == "refresh_tracks" then
         refreshTrackMapping()
+    elseif action == "track_names_available" then
+        -- Track names received from document script
+        if needsRefresh then
+            processTrackNames(value)
+        end
     elseif action == "clear_mapping" then
         -- Clear listeners
         clearListeners()


### PR DESCRIPTION
## Problem
When "push refresh all" is triggered, each track group independently calls `/live/song/get/track_names` and `/live/song/get/return_track_names`, causing unnecessary duplicate OSC packets. With many track groups, this creates a burst of identical requests.

## Solution
Centralize track name retrieval in the document script. The document script will:
1. Query track names once per connection
2. Cache the results
3. Distribute them to all track groups via notifications

This ensures only one set of track name queries per connection, regardless of how many track groups exist.

## Changes
- Modified document_script.lua to cache and distribute track names
- Modified group_init.lua to receive track names via notification instead of querying directly
- Version updates: document_script.lua to 2.10.0, group_init.lua to 1.17.0

## Testing
- [ ] Verify refresh only sends one track names query per connection
- [ ] Verify all track groups still map correctly
- [ ] Test with multiple connections
- [ ] Test with both regular and return tracks