### PR TITLE
Fix refresh timing for slower Android tablets

### DIFF
--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -1,32 +1,35 @@
 # Thread Progress Tracking
 
 ## CRITICAL CURRENT STATE
-**⚠️ PR #26 IN PROGRESS:**
-- [ ] Currently working on: Fix duplicate track names calls during refresh
-- [ ] Waiting for: User testing of centralized track names retrieval
+**⚠️ PR #28 IN PROGRESS:**
+- [ ] Currently working on: Fix Android tablet refresh timing issue
+- [ ] Waiting for: User testing on Android tablet with 200 tracks
 - [ ] Blocked by: None
 
-## ACTIVE WORK: DUPLICATE TRACK NAMES FIX
+## ACTIVE WORK: ANDROID TABLET REFRESH TIMING FIX
 ### Problem Identified:
-- Each track group independently calls `/live/song/get/track_names`
-- Causes duplicate OSC packets during refresh
-- Creates unnecessary network traffic
+- On slower Android tablets with 200 tracks, faders sometimes not mapped during refresh
+- Track name responses arrive before groups process refresh notification
+- Timing issue between refresh button and group receive
 
 ### Solution Implemented:
-1. **Centralized Queries**: ✅
-   - Document script queries track names once per connection
-   - Caches results in `trackNamesCache`
-   - Distributes to all groups via notification
+1. **Added delay between notify and query**: ✅
+   - 50ms delay after notifying groups before querying track names
+   - Gives slower devices time to set needsRefresh flag
 
 2. **Updated Scripts**: ✅
-   - `document_script.lua` v2.10.0 - Centralized querying
-   - `group_init.lua` v1.17.0 - Receives names via notification
+   - `document_script.lua` v2.11.0 - Added notifying state with delay
 
 3. **Testing Required**: ❌
-   - [ ] Verify only one track names query per connection
-   - [ ] Test all track groups map correctly
-   - [ ] Test with multiple connections
-   - [ ] Test with both regular and return tracks
+   - [ ] Test on Windows TouchOSC (should work normally)
+   - [ ] Test on slower Android tablet with 200 tracks
+   - [ ] Verify all faders map correctly on both platforms
+
+## COMPLETED WORK: PR #26 MERGED
+### Duplicate Track Names Fix: COMPLETE
+- [x] Centralized track names retrieval MERGED
+- [x] Prevents duplicate OSC calls during refresh
+- [x] Version 2.10.0 released
 
 ## COMPLETED WORK: DOUBLE-CLICK MUTE (PR #24)
 ### Final Status: READY FOR MERGE
@@ -40,21 +43,21 @@
 ## Testing Status Matrix
 | Component | Implemented | Unit Tested | Integration Tested | Multi-Instance Tested | 
 |-----------|------------|-------------|--------------------|-----------------------|
-| document_script v2.10.0 | ✅ | ❌ | ❌ | ❌ |
-| group_init v1.17.0 | ✅ | ❌ | ❌ | ❌ |
+| document_script v2.11.0 | ✅ | ❌ | ❌ | ❌ |
+| group_init v1.17.0 | ✅ | ✅ | ✅ | ✅ |
 | mute_button v2.7.0 | ✅ | ✅ | ✅ | ✅ |
 | mute_display_label v1.0.1 | ✅ | ✅ | ✅ | ✅ |
 
 ## Last User Action
-- Date/Time: 2025-07-07 12:58
-- Action: Reported duplicate track names calls issue
-- Result: Created PR #26 with centralized solution
-- Next Required: Test the fix and provide logs
+- Date/Time: 2025-07-09 09:30
+- Action: Reported Android tablet refresh issue
+- Result: Created PR #28 with timing fix
+- Next Required: Test the fix on Android tablet
 
 ## NEXT STEPS
-1. User tests PR #26 branch
-2. Verify OSC log shows single track names query
-3. Confirm all track groups still map correctly
-4. If working, merge PR #26
+1. User tests PR #28 branch on Android tablet
+2. Verify refresh works correctly with 200 tracks
+3. Confirm Windows TouchOSC still works normally
+4. If working, merge PR #28
 5. Then merge PR #24 (double-click mute)
 6. Create v1.5.0 release

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -2,7 +2,7 @@
 
 ## CRITICAL CURRENT STATE
 **⚠️ PR #28 IN PROGRESS:**
-- [ ] Currently working on: Fix Android tablet refresh timing issue
+- [ ] Currently working on: Fix Android tablet refresh timing issue with simple 2s delay
 - [ ] Waiting for: User testing on Android tablet with 200 tracks
 - [ ] Blocked by: None
 
@@ -10,15 +10,16 @@
 ### Problem Identified:
 - On slower Android tablets with 200 tracks, faders sometimes not mapped during refresh
 - Track name responses arrive before groups process refresh notification
-- Timing issue between refresh button and group receive
+- Previous complex solutions didn't work
 
 ### Solution Implemented:
-1. **Added delay between notify and query**: ✅
-   - 50ms delay after notifying groups before querying track names
-   - Gives slower devices time to set needsRefresh flag
+1. **Simple 2-second delay**: ✅
+   - Clear mappings → Wait 100ms → Notify groups → Wait 2s → Query track names
+   - Groups have 2 full seconds to prepare before track names are queried
+   - Status shows "Preparing (2s)..." during wait
 
 2. **Updated Scripts**: ✅
-   - `document_script.lua` v2.11.0 - Added notifying state with delay
+   - `document_script.lua` v2.13.0 - Simple timing approach
 
 3. **Testing Required**: ❌
    - [ ] Test on Windows TouchOSC (should work normally)
@@ -43,15 +44,15 @@
 ## Testing Status Matrix
 | Component | Implemented | Unit Tested | Integration Tested | Multi-Instance Tested | 
 |-----------|------------|-------------|--------------------|-----------------------|
-| document_script v2.11.0 | ✅ | ❌ | ❌ | ❌ |
+| document_script v2.13.0 | ✅ | ❌ | ❌ | ❌ |
 | group_init v1.17.0 | ✅ | ✅ | ✅ | ✅ |
 | mute_button v2.7.0 | ✅ | ✅ | ✅ | ✅ |
 | mute_display_label v1.0.1 | ✅ | ✅ | ✅ | ✅ |
 
 ## Last User Action
-- Date/Time: 2025-07-09 09:30
-- Action: Reported Android tablet refresh issue
-- Result: Created PR #28 with timing fix
+- Date/Time: 2025-07-10 12:20
+- Action: Requested simple approach with 2s delay
+- Result: Implemented simple timing solution
 - Next Required: Test the fix on Android tablet
 
 ## NEXT STEPS

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -2,29 +2,30 @@
 
 ## CRITICAL CURRENT STATE
 **⚠️ PR #28 IN PROGRESS:**
-- [ ] Currently working on: Fix Android tablet refresh timing issue with simple 2s delay
-- [ ] Waiting for: User testing on Android tablet with 200 tracks
+- [ ] Currently working on: Investigating wrong connection issue for band groups
+- [ ] Waiting for: Analysis of OSC message routing
 - [ ] Blocked by: None
 
-## ACTIVE WORK: ANDROID TABLET REFRESH TIMING FIX
-### Problem Identified:
-- On slower Android tablets with 200 tracks, faders sometimes not mapped during refresh
-- Track name responses arrive before groups process refresh notification
-- Previous complex solutions didn't work
+## ACTIVE WORK: ANDROID TABLET REFRESH ISSUE - NEW DISCOVERY
+### Problem Evolution:
+1. Initially thought it was timing issue on slower tablets
+2. Tried various delays (50ms, 150ms, 500ms, 2s)
+3. User discovered the real issue: Groups are processing OSC messages from wrong connection
 
-### Solution Implemented:
-1. **Simple 2-second delay**: ✅
-   - Clear mappings → Wait 100ms → Notify groups → Wait 2s → Query track names
-   - Groups have 2 full seconds to prepare before track names are queried
-   - Status shows "Preparing (2s)..." during wait
+### Current Investigation:
+- Log shows "GROUP(band_STEVO repro#): Track not found: STEVO repro#"
+- This group should process band connection messages
+- Appears to be processing master connection messages instead
+- Need to add logging to see which connection's OSC message is being processed
 
-2. **Updated Scripts**: ✅
-   - `document_script.lua` v2.13.0 - Simple timing approach
+### Solution Implemented So Far:
+1. **500ms delay**: ✅ (but doesn't fix the real issue)
+   - `document_script.lua` v2.13.1 - Simple timing approach
 
-3. **Testing Required**: ❌
-   - [ ] Test on Windows TouchOSC (should work normally)
-   - [ ] Test on slower Android tablet with 200 tracks
-   - [ ] Verify all faders map correctly on both platforms
+### Next Steps:
+1. Add logging to show which connection's OSC message groups are processing
+2. Verify connection filtering in group_init.lua
+3. Fix connection routing issue
 
 ## COMPLETED WORK: PR #26 MERGED
 ### Duplicate Track Names Fix: COMPLETE
@@ -44,21 +45,21 @@
 ## Testing Status Matrix
 | Component | Implemented | Unit Tested | Integration Tested | Multi-Instance Tested | 
 |-----------|------------|-------------|--------------------|-----------------------|
-| document_script v2.13.0 | ✅ | ❌ | ❌ | ❌ |
-| group_init v1.17.0 | ✅ | ✅ | ✅ | ✅ |
+| document_script v2.13.1 | ✅ | ❌ | ❌ | ❌ |
+| group_init v1.17.0 | ✅ | ❌ | ❌ | ❌ |
 | mute_button v2.7.0 | ✅ | ✅ | ✅ | ✅ |
 | mute_display_label v1.0.1 | ✅ | ✅ | ✅ | ✅ |
 
 ## Last User Action
-- Date/Time: 2025-07-10 12:20
-- Action: Requested simple approach with 2s delay
-- Result: Implemented simple timing solution
-- Next Required: Test the fix on Android tablet
+- Date/Time: 2025-07-10 12:55
+- Action: Discovered groups processing wrong connection's OSC messages
+- Result: Need to investigate connection filtering
+- Next Required: Add logging to identify connection source
 
 ## NEXT STEPS
-1. User tests PR #28 branch on Android tablet
-2. Verify refresh works correctly with 200 tracks
-3. Confirm Windows TouchOSC still works normally
+1. Add logging to show which connection OSC messages come from
+2. Fix connection filtering in group_init.lua
+3. Test on Android tablet again
 4. If working, merge PR #28
 5. Then merge PR #24 (double-click mute)
 6. Create v1.5.0 release

--- a/THREAD_PROGRESS.md
+++ b/THREAD_PROGRESS.md
@@ -2,30 +2,28 @@
 
 ## CRITICAL CURRENT STATE
 **⚠️ PR #28 IN PROGRESS:**
-- [ ] Currently working on: Investigating wrong connection issue for band groups
-- [ ] Waiting for: Analysis of OSC message routing
-- [ ] Blocked by: None
+- [ ] Currently working on: Waiting for user to test with detailed logging v1.17.2
+- [ ] Waiting for: User to run refresh and provide logs showing track names received vs expected
+- [ ] Blocked by: Need diagnostic logs to identify track name mismatch
 
-## ACTIVE WORK: ANDROID TABLET REFRESH ISSUE - NEW DISCOVERY
+## ACTIVE WORK: ANDROID TABLET REFRESH ISSUE - DIAGNOSTICS ADDED
 ### Problem Evolution:
 1. Initially thought it was timing issue on slower tablets
 2. Tried various delays (50ms, 150ms, 500ms, 2s)
-3. User discovered the real issue: Groups are processing OSC messages from wrong connection
+3. User discovered the real issue: Groups can't find matching track names in received list
+4. Example: Group "band_STEVO repro#" looking for track "STEVO repro#" - not found
 
-### Current Investigation:
-- Log shows "GROUP(band_STEVO repro#): Track not found: STEVO repro#"
-- This group should process band connection messages
-- Appears to be processing master connection messages instead
-- Need to add logging to see which connection's OSC message is being processed
-
-### Solution Implemented So Far:
+### Solution Implemented:
 1. **500ms delay**: ✅ (but doesn't fix the real issue)
    - `document_script.lua` v2.13.1 - Simple timing approach
+2. **Detailed logging**: ✅ NEW
+   - `group_init.lua` v1.17.2 - Logs all track names received with lengths
+   - Will show exact mismatch between expected vs received names
 
 ### Next Steps:
-1. Add logging to show which connection's OSC message groups are processing
-2. Verify connection filtering in group_init.lua
-3. Fix connection routing issue
+1. User needs to test with v1.17.2 and provide logs
+2. Analyze logs to see track name differences (extra spaces, special chars, etc.)
+3. Implement fix based on findings
 
 ## COMPLETED WORK: PR #26 MERGED
 ### Duplicate Track Names Fix: COMPLETE
@@ -46,20 +44,21 @@
 | Component | Implemented | Unit Tested | Integration Tested | Multi-Instance Tested | 
 |-----------|------------|-------------|--------------------|-----------------------|
 | document_script v2.13.1 | ✅ | ❌ | ❌ | ❌ |
-| group_init v1.17.0 | ✅ | ❌ | ❌ | ❌ |
+| group_init v1.17.2 | ✅ | ❌ | ❌ | ❌ |
 | mute_button v2.7.0 | ✅ | ✅ | ✅ | ✅ |
 | mute_display_label v1.0.1 | ✅ | ✅ | ✅ | ✅ |
 
 ## Last User Action
-- Date/Time: 2025-07-10 12:55
-- Action: Discovered groups processing wrong connection's OSC messages
-- Result: Need to investigate connection filtering
-- Next Required: Add logging to identify connection source
+- Date/Time: 2025-07-10 13:45
+- Action: Added detailed logging to group_init.lua v1.17.2
+- Result: Ready for user to test and provide diagnostic logs
+- Next Required: User to run refresh and share logs showing track names
 
 ## NEXT STEPS
-1. Add logging to show which connection OSC messages come from
-2. Fix connection filtering in group_init.lua
-3. Test on Android tablet again
-4. If working, merge PR #28
-5. Then merge PR #24 (double-click mute)
-6. Create v1.5.0 release
+1. Wait for user to test with new logging
+2. Analyze logs to identify track name mismatch
+3. Fix based on findings (trim spaces, handle special chars, etc.)
+4. Test on Android tablet again
+5. If working, merge PR #28
+6. Then merge PR #24 (double-click mute)
+7. Create v1.5.0 release

--- a/scripts/document_script.lua
+++ b/scripts/document_script.lua
@@ -1,13 +1,13 @@
 -- TouchOSC Document Script (formerly helper_script.lua)
--- Version: 2.12.0
+-- Version: 2.13.0
 -- Purpose: Main document script with configuration and track management
--- Changed: Increased delays and added verification for slower Android tablets
+-- Changed: Simple 2-second delay to ensure groups are ready on slower devices
 
-local VERSION = "2.12.0"
+local VERSION = "2.13.0"
 local SCRIPT_NAME = "Document Script"
 
 -- Debug flag - set to 1 to enable logging
-local DEBUG = 1  -- Enabled for troubleshooting
+local DEBUG = 0
 
 -- Configuration storage
 local config = {
@@ -25,17 +25,13 @@ local trackGroups = {}
 -- Startup tracking
 local startupRefreshTime = nil
 local frameCount = 0
-local STARTUP_DELAY_FRAMES = 120  -- Wait 2 seconds (120 frames at 60fps) for slower devices
+local STARTUP_DELAY_FRAMES = 120  -- Wait 2 seconds (120 frames at 60fps)
 
 -- Refresh state tracking
 local refreshState = "idle"  -- idle, clearing, waiting, notifying, refreshing
 local refreshWaitStart = 0
-local REFRESH_WAIT_TIME = 200  -- 200ms delay between clear and refresh (increased from 100ms)
-local NOTIFY_WAIT_TIME = 150   -- 150ms delay after notifying groups before querying (increased from 50ms)
-
--- Track readiness
-local groupsNotified = 0
-local groupsToNotify = 0
+local REFRESH_WAIT_TIME = 100  -- 100ms delay between clear and notify
+local NOTIFY_WAIT_TIME = 2000  -- 2 SECONDS delay after notifying groups before querying
 
 -- === LOCAL LOGGING FUNCTION ===
 local function log(message)
@@ -133,10 +129,6 @@ function onReceiveNotify(action, value)
             trackGroups[value.name] = value
             log("Registered track group: " .. value.name)
         end
-    elseif action == "group_refresh_ready" then
-        -- Group has confirmed it's ready for refresh
-        groupsNotified = groupsNotified + 1
-        log("Group ready: " .. groupsNotified .. "/" .. groupsToNotify)
     end
     -- Note: Removed "configuration_updated" handler - config text is read-only at runtime
     -- Note: Removed "log_message" handler - each script logs independently now
@@ -152,27 +144,24 @@ function startRefreshSequence()
         status.values.text = "Clearing..."
     end
     
-    -- Count and validate groups
+    -- Count groups
     local groupCount = 0
-    local validGroups = 0
-    for name, group in pairs(trackGroups) do
+    for name, _ in pairs(trackGroups) do
         groupCount = groupCount + 1
+    end
+    
+    -- Clear all track mappings first
+    for name, group in pairs(trackGroups) do
         -- Verify group still exists and is valid
         if group and group.notify then
             group:notify("clear_mapping")
-            validGroups = validGroups + 1
         else
             -- Remove invalid reference
             trackGroups[name] = nil
-            log("Removed invalid group: " .. name)
         end
     end
     
-    log("Cleared " .. validGroups .. " valid groups (out of " .. groupCount .. " total)")
-    
-    -- Reset notification tracking
-    groupsNotified = 0
-    groupsToNotify = validGroups
+    log("Cleared " .. groupCount .. " groups")
     
     -- Set state to wait before refreshing
     refreshState = "waiting"
@@ -191,11 +180,8 @@ function notifyGroupsForRefresh()
     -- Update status
     local status = root:findByName("global_status")
     if status then
-        status.values.text = "Preparing..."
+        status.values.text = "Preparing (2s)..."
     end
-    
-    -- Count groups to notify
-    local notifiedCount = 0
     
     -- Notify all groups to prepare for refresh
     -- This sets their needsRefresh flag so they'll process incoming track names
@@ -203,13 +189,10 @@ function notifyGroupsForRefresh()
         -- Verify group still exists and is valid
         if group and group.notify then
             group:notify("refresh_tracks")
-            notifiedCount = notifiedCount + 1
         end
     end
     
-    log("Notified " .. notifiedCount .. " groups to prepare")
-    
-    -- Set state to wait before querying
+    -- Set state to wait 2 seconds before querying
     refreshState = "notifying"
     refreshWaitStart = getMillis()
 end
@@ -224,17 +207,8 @@ function completeRefreshSequence()
         status.values.text = "Refreshing..."
     end
     
-    -- Add a small extra delay for very slow devices
-    local extraDelay = 50
-    local currentTime = getMillis()
-    while (getMillis() - currentTime) < extraDelay do
-        -- Wait
-    end
-    
     -- Query track names once per connection
     local uniqueConnections = {}
-    local queriedConnections = 0
-    
     for instance, connIndex in pairs(config.connections) do
         if not uniqueConnections[connIndex] then
             uniqueConnections[connIndex] = true
@@ -249,12 +223,9 @@ function completeRefreshSequence()
             sendOSC('/live/song/get/track_names', connections)
             sendOSC('/live/song/get/return_track_names', connections)
             
-            queriedConnections = queriedConnections + 1
             log("Queried connection " .. connIndex)
         end
     end
-    
-    log("Sent track name queries to " .. queriedConnections .. " connections")
     
     -- Update status
     if status then

--- a/scripts/document_script.lua
+++ b/scripts/document_script.lua
@@ -1,13 +1,13 @@
 -- TouchOSC Document Script (formerly helper_script.lua)
--- Version: 2.13.1
+-- Version: 2.13.2
 -- Purpose: Main document script with configuration and track management
--- Changed: Set delay to 500ms for Android tablet refresh timing
+-- Changed: Enable debug logging to troubleshoot connection routing
 
-local VERSION = "2.13.1"
+local VERSION = "2.13.2"
 local SCRIPT_NAME = "Document Script"
 
 -- Debug flag - set to 1 to enable logging
-local DEBUG = 0
+local DEBUG = 1  -- ENABLED FOR TROUBLESHOOTING
 
 -- Configuration storage
 local config = {
@@ -250,7 +250,7 @@ end
 function createConnectionTable(connectionIndex)
     local connections = {}
     for i = 1, 10 do
-        connections[i] = (i == connectionIndex)
+        connections[i] = (i == connIndex)
     end
     return connections
 end

--- a/scripts/document_script.lua
+++ b/scripts/document_script.lua
@@ -1,9 +1,9 @@
 -- TouchOSC Document Script (formerly helper_script.lua)
--- Version: 2.13.0
+-- Version: 2.13.1
 -- Purpose: Main document script with configuration and track management
--- Changed: Simple 2-second delay to ensure groups are ready on slower devices
+-- Changed: Set delay to 500ms for Android tablet refresh timing
 
-local VERSION = "2.13.0"
+local VERSION = "2.13.1"
 local SCRIPT_NAME = "Document Script"
 
 -- Debug flag - set to 1 to enable logging
@@ -31,7 +31,7 @@ local STARTUP_DELAY_FRAMES = 120  -- Wait 2 seconds (120 frames at 60fps)
 local refreshState = "idle"  -- idle, clearing, waiting, notifying, refreshing
 local refreshWaitStart = 0
 local REFRESH_WAIT_TIME = 100  -- 100ms delay between clear and notify
-local NOTIFY_WAIT_TIME = 2000  -- 2 SECONDS delay after notifying groups before querying
+local NOTIFY_WAIT_TIME = 500   -- 500ms delay after notifying groups before querying
 
 -- === LOCAL LOGGING FUNCTION ===
 local function log(message)
@@ -180,7 +180,7 @@ function notifyGroupsForRefresh()
     -- Update status
     local status = root:findByName("global_status")
     if status then
-        status.values.text = "Preparing (2s)..."
+        status.values.text = "Preparing..."
     end
     
     -- Notify all groups to prepare for refresh
@@ -192,7 +192,7 @@ function notifyGroupsForRefresh()
         end
     end
     
-    -- Set state to wait 2 seconds before querying
+    -- Set state to wait 500ms before querying
     refreshState = "notifying"
     refreshWaitStart = getMillis()
 end

--- a/scripts/track/group_init.lua
+++ b/scripts/track/group_init.lua
@@ -1,9 +1,9 @@
 -- TouchOSC Group Initialization Script with Auto Track Type Detection
--- Version: 1.17.1
--- Changed: Added connection logging to debug routing issue
+-- Version: 1.17.2
+-- Changed: Added detailed track name logging to diagnose matching issues
 
 -- Version constant
-local SCRIPT_VERSION = "1.17.1"
+local SCRIPT_VERSION = "1.17.2"
 
 -- Debug flag - set to 1 to enable logging
 local DEBUG = 1  -- ENABLED FOR TROUBLESHOOTING
@@ -198,6 +198,7 @@ function init()
     -- Log initialization
     log("Script v" .. SCRIPT_VERSION .. " loaded")
     log("Instance: " .. instance .. ", Expected connection: " .. connectionIndex)
+    log("Looking for track: '" .. trackName .. "' (length: " .. #trackName .. ")")
     
     -- Register this group with the document script
     root:notify("register_track_group", self)
@@ -297,9 +298,12 @@ function onReceiveOSC(message, connections)
             local arguments = message[2]
             
             if arguments then
+                -- Log all track names received
+                log("Received " .. #arguments .. " track names:")
                 for i = 1, #arguments do
                     if arguments[i] and arguments[i].value then
                         local trackNameValue = arguments[i].value
+                        log("  Track " .. (i-1) .. ": '" .. trackNameValue .. "' (length: " .. #trackNameValue .. ")")
                         
                         -- EXACT match only for safety
                         if trackNameValue == trackName then
@@ -310,7 +314,7 @@ function onReceiveOSC(message, connections)
                             trackMapped = true
                             needsRefresh = false  -- Found it, stop searching
                             
-                            log("Mapped to track " .. trackNumber)
+                            log("MATCHED! Mapped to track " .. trackNumber)
                             
                             setGroupEnabled(true)
                             
@@ -336,6 +340,7 @@ function onReceiveOSC(message, connections)
                         end
                     end
                 end
+                log("Track '" .. trackName .. "' not found in regular tracks")
             end
         end
     end
@@ -357,9 +362,12 @@ function onReceiveOSC(message, connections)
             local arguments = message[2]
             
             if arguments then
+                -- Log all return track names received
+                log("Received " .. #arguments .. " return track names:")
                 for i = 1, #arguments do
                     if arguments[i] and arguments[i].value then
                         local returnNameValue = arguments[i].value
+                        log("  Return " .. (i-1) .. ": '" .. returnNameValue .. "' (length: " .. #returnNameValue .. ")")
                         
                         -- EXACT match only for safety
                         if returnNameValue == trackName then
@@ -370,7 +378,7 @@ function onReceiveOSC(message, connections)
                             trackMapped = true
                             needsRefresh = false
                             
-                            log("Mapped to return " .. trackNumber)
+                            log("MATCHED! Mapped to return " .. trackNumber)
                             
                             setGroupEnabled(true)
                             
@@ -396,6 +404,7 @@ function onReceiveOSC(message, connections)
                         end
                     end
                 end
+                log("Track '" .. trackName .. "' not found in return tracks")
             end
             
             -- If we've checked both regular and return tracks and didn't find it


### PR DESCRIPTION
## Problem
On slower Android tablets with 200 tracks, faders are sometimes not mapped correctly when using \"refresh all\". ~~The track name responses arrive before all groups have processed the refresh notification.~~ **UPDATE**: Groups are receiving OSC messages but can't find matching track names.

## Solution
~~Simple approach: Add a 500ms delay between notifying groups to prepare for refresh and actually querying track names. This ensures all groups are ready before the track name data arrives.~~ **Investigating**: Added detailed logging to diagnose why track names don't match.

## Changes
- Modified `document_script.lua` to wait 500ms after notifying groups
- Simple refresh sequence: Clear → Wait 100ms → Notify → Wait 500ms → Query
- **NEW**: Added detailed track name logging in `group_init.lua` v1.17.2 to see exactly what's being received

## Testing
- [ ] Test refresh on Windows TouchOSC (should still work normally)
- [ ] Test refresh on slower Android tablet with 200 tracks
- [ ] **Check logs to see what track names are being received vs expected**
- [ ] Verify all faders map correctly on both platforms

## Investigation Log
- User discovered groups are looking for tracks that don't exist in the received list
- Example: Group \"band_STEVO repro#\" can't find track \"STEVO repro#\"
- Added detailed logging to see all track names received from each connection